### PR TITLE
fix: correct accent mappings and update tests

### DIFF
--- a/__tests__/mocks/mathmlStrings.ts
+++ b/__tests__/mocks/mathmlStrings.ts
@@ -2811,7 +2811,7 @@ export const inputExpectedPairs = [
   },
   {
     input: 'ő',
-    expected: '\\ddot{o}',
+    expected: '\\H{o}',
     op: 'mi',
   },
   {
@@ -3311,7 +3311,7 @@ export const inputExpectedPairs = [
   },
   {
     input: 'Ú',
-    expected: '\\grave{U}',
+    expected: '\\acute{U}',
     op: 'mi',
   },
   {

--- a/src/syntax/utf8-converter.ts
+++ b/src/syntax/utf8-converter.ts
@@ -91,7 +91,8 @@ type LTXAccentCMD =
   | 'dot'
   | 'mathring'
   | 'bar'
-  | 'vec';
+  | 'vec'
+  | 'H';
 
 const vowelsWithAccents: Record<string, AccentChar> = {
   á: { char: 'a', accent: '´' },
@@ -234,15 +235,15 @@ const vowelsWithAccents: Record<string, AccentChar> = {
 };
 
 const accentToLTXCmd: Record<Accent, LTXAccentCMD> = {
-  '´': 'grave',
-  '`': 'acute',
+  '´': 'acute',
+  '`': 'grave',
   '^': 'hat',
   '~': 'tilde',
   '¨': 'ddot',
   '˚': 'mathring',
   '˘': 'breve',
   ˇ: 'check',
-  '˝': 'ddot',
+  '˝': 'H',
   '˙': 'dot',
   '-': 'bar',
   ˆ: 'hat',


### PR DESCRIPTION
Fixes #35 

This PR corrects the LaTeX command mappings for double acute (`˝`), acute (`´`), and grave (\`) accents in the `accentToLTXCmd` map within `src/syntax/utf8-converter.ts`.

It also updates the relevant test assertions to expect the correct LaTeX output (e.g., `\H{o}` instead of `\ddot{o}` for `ő`).