### PR TITLE
fix(parser): guard against deep recursion DoS

### DIFF
--- a/__tests__/security/robustness.test.ts
+++ b/__tests__/security/robustness.test.ts
@@ -1,4 +1,5 @@
 import { MathMLToLaTeX } from '../../src';
+import { MaxDepthExceededError } from '../../src/data/errors';
 
 /**
  * Security/robustness tests derived from issue #44 (vulnerable @xmldom/xmldom).
@@ -59,18 +60,24 @@ describe('#convert security and robustness', () => {
   });
 
   describe('given deeply nested input (denial of service)', () => {
-    // Skipped: the converter still recurses over the element tree (and again on
-    // the LaTeX side), so deep input overflows the call stack. Tracked as a
-    // follow-up (depth guard or iterative traversal); unskip once fixed.
-    it.skip('does not blow the stack on deeply nested mrow elements', () => {
+    it('rejects deeply nested input with a domain error instead of crashing', () => {
       const depth = 20000;
       const inner = '<mrow>'.repeat(depth) + '<mn>1</mn>' + '</mrow>'.repeat(depth);
       const mathml = `<math>${inner}</math>`;
 
-      // The contract is "no uncontrolled crash": it may convert successfully or
-      // reject with a domain error, but it must never throw a raw RangeError
-      // (Maximum call stack size exceeded).
+      // The depth guard must trip before the recursion can overflow the call
+      // stack, so a controlled MaxDepthExceededError is raised, never a raw
+      // RangeError (Maximum call stack size exceeded).
+      expect(() => MathMLToLaTeX.convert(mathml)).toThrow(MaxDepthExceededError);
       expect(() => MathMLToLaTeX.convert(mathml)).not.toThrow(RangeError);
+    });
+
+    it('still converts input nested within the supported depth', () => {
+      const depth = 100;
+      const inner = '<mrow>'.repeat(depth) + '<mn>1</mn>' + '</mrow>'.repeat(depth);
+      const mathml = `<math>${inner}</math>`;
+
+      expect(() => MathMLToLaTeX.convert(mathml)).not.toThrow();
     });
   });
 });

--- a/src/data/errors/index.ts
+++ b/src/data/errors/index.ts
@@ -1,1 +1,2 @@
 export { InvalidNumberOfChildrenError } from './invalid-number-of-children';
+export { MaxDepthExceededError } from './max-depth-exceeded';

--- a/src/data/errors/max-depth-exceeded.ts
+++ b/src/data/errors/max-depth-exceeded.ts
@@ -1,0 +1,6 @@
+export class MaxDepthExceededError extends Error {
+  constructor(maxDepth: number) {
+    super(`MathML nesting is too deep. Maximum supported depth is ${maxDepth}.`);
+    this.name = 'MaxDepthExceededError';
+  }
+}

--- a/src/infra/usecases/xmldom-to-mathml-elements/xmldom-elements-to-mathml-elements-adapter.ts
+++ b/src/infra/usecases/xmldom-to-mathml-elements/xmldom-elements-to-mathml-elements-adapter.ts
@@ -1,17 +1,24 @@
 import { MathMLElement } from '../../../data/protocols/mathml-element';
+import { MaxDepthExceededError } from '../../../data/errors';
+
+// Bounds the recursive traversal so that pathologically deep input cannot
+// overflow the call stack (here or on the LaTeX conversion that walks the same
+// tree afterwards). Real-world MathML nesting is orders of magnitude shallower.
+const MAX_DEPTH = 1000;
 
 export class ElementsToMathMLAdapter {
-  convert(els: Element[]): MathMLElement[] {
-    return els.filter((el: Element) => el.tagName !== undefined).map((el: Element) => this._convertElement(el));
+  convert(els: Element[], depth = 0): MathMLElement[] {
+    if (depth > MAX_DEPTH) throw new MaxDepthExceededError(MAX_DEPTH);
+    return els.filter((el: Element) => el.tagName !== undefined).map((el: Element) => this._convertElement(el, depth));
   }
 
-  private _convertElement(el: Element): MathMLElement {
+  private _convertElement(el: Element, depth: number): MathMLElement {
     return {
       name: el.tagName,
       attributes: this._convertElementAttributes(el.attributes),
       value: this._hasElementChild(el) ? '' : el.textContent || '',
       children: this._hasElementChild(el)
-        ? this.convert(Array.from(el.childNodes) as Element[])
+        ? this.convert(Array.from(el.childNodes) as Element[], depth + 1)
         : ([] as MathMLElement[]),
     };
   }


### PR DESCRIPTION
## Summary
Deeply nested MathML (e.g. thousands of nested `<mrow>`) overflowed the call stack with an uncontrolled `RangeError`, since the converter recurses over the element tree and again on the LaTeX side. This is a denial-of-service vector when converting untrusted input.

## Changes
- Add a depth guard (`MAX_DEPTH = 1000`) in the element-tree traversal, which also protects the subsequent LaTeX pass that walks the same tree
- Reject pathologically deep input with a controlled `MaxDepthExceededError` instead of crashing
- Enable the previously skipped DoS robustness test and add a coverage case for legitimate nested input

🤖 Generated with [Claude Code](https://claude.com/claude-code)