### PR TITLE
fix(parser): convert MathML tree iteratively to avoid stack overflow

### DIFF
--- a/__tests__/security/robustness.test.ts
+++ b/__tests__/security/robustness.test.ts
@@ -59,18 +59,15 @@ describe('#convert security and robustness', () => {
   });
 
   describe('given deeply nested input (denial of service)', () => {
-    // Skipped: the converter still recurses over the element tree (and again on
-    // the LaTeX side), so deep input overflows the call stack. Tracked as a
-    // follow-up (depth guard or iterative traversal); unskip once fixed.
-    it.skip('does not blow the stack on deeply nested mrow elements', () => {
+    it('converts deeply nested input without overflowing the call stack', () => {
       const depth = 20000;
       const inner = '<mrow>'.repeat(depth) + '<mn>1</mn>' + '</mrow>'.repeat(depth);
       const mathml = `<math>${inner}</math>`;
 
-      // The contract is "no uncontrolled crash": it may convert successfully or
-      // reject with a domain error, but it must never throw a raw RangeError
-      // (Maximum call stack size exceeded).
-      expect(() => MathMLToLaTeX.convert(mathml)).not.toThrow(RangeError);
+      // The conversion is fully iterative, so even pathologically deep nesting
+      // is converted instead of crashing with a RangeError.
+      expect(() => MathMLToLaTeX.convert(mathml)).not.toThrow();
+      expect(MathMLToLaTeX.convert(mathml)).toBe('1');
     });
   });
 });

--- a/src/data/helpers/mathml-element-to-latex-converter.ts
+++ b/src/data/helpers/mathml-element-to-latex-converter.ts
@@ -2,5 +2,29 @@ import { MathMLElement } from '../protocols/mathml-element';
 import { ToLaTeXConverter } from '../../domain/usecases/to-latex-converter';
 import { MathMLElementToLatexConverterAdapter } from '../usecases/mathml-to-latex-convertion/mathml-element-to-latex-converter-adapter';
 
-export const mathMLElementToLaTeXConverter = (mathMLElement: MathMLElement): ToLaTeXConverter =>
-  new MathMLElementToLatexConverterAdapter(mathMLElement).toLatexConverter();
+// During an iterative conversion (see tree-to-latex) every child is converted
+// before its parent and its LaTeX is stored in this memo. While a memo is
+// active, the helper returns the child's precomputed string instead of building
+// a converter that would recurse — keeping the call stack flat at any depth.
+let conversionMemo: Map<MathMLElement, string> | null = null;
+
+export const setConversionMemo = (memo: Map<MathMLElement, string> | null): Map<MathMLElement, string> | null => {
+  const previous = conversionMemo;
+  conversionMemo = memo;
+  return previous;
+};
+
+export const mathMLElementToLaTeXConverter = (mathMLElement: MathMLElement): ToLaTeXConverter => {
+  const precomputed = conversionMemo?.get(mathMLElement);
+  if (precomputed !== undefined) return new PrecomputedConverter(precomputed);
+
+  return new MathMLElementToLatexConverterAdapter(mathMLElement).toLatexConverter();
+};
+
+class PrecomputedConverter implements ToLaTeXConverter {
+  constructor(private readonly _latex: string) {}
+
+  convert(): string {
+    return this._latex;
+  }
+}

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mfenced.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mfenced.ts
@@ -32,9 +32,17 @@ export class MFenced implements ToLaTeXConverter {
   }
 
   private _isThereRelativeOfName(mathmlElements: MathMLElement[], elementName: string): boolean {
-    return mathmlElements.some(
-      (child) => child.name === elementName || this._isThereRelativeOfName(child.children, elementName),
-    );
+    // Iterative depth-first search so a deeply nested subtree cannot overflow
+    // the call stack.
+    const stack = [...mathmlElements];
+
+    while (stack.length > 0) {
+      const element = stack.pop() as MathMLElement;
+      if (element.name === elementName) return true;
+      stack.push(...(element.children ?? []));
+    }
+
+    return false;
   }
 }
 

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mtable.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mtable.ts
@@ -7,7 +7,6 @@ export class MTable implements ToLaTeXConverter {
 
   constructor(mathElement: MathMLElement) {
     this._mathmlElement = mathElement;
-    this._addFlagRecursiveIfName(this._mathmlElement.children, 'mtable', 'innerTable');
   }
 
   convert(): string {
@@ -16,18 +15,12 @@ export class MTable implements ToLaTeXConverter {
       .map((converter) => converter.convert())
       .join(' \\\\\n');
 
+    // The `innerTable` flag is set by the iterative pre-pass in tree-to-latex.
     return this._hasFlag('innerTable') ? this._wrap(tableContent) : tableContent;
   }
 
   private _wrap(latex: string): string {
     return `\\begin{matrix}${latex}\\end{matrix}`;
-  }
-
-  private _addFlagRecursiveIfName(mathmlElements: MathMLElement[], name: string, flag: string): void {
-    mathmlElements.forEach((mathmlElement) => {
-      if (mathmlElement.name === name) mathmlElement.attributes[flag] = flag;
-      this._addFlagRecursiveIfName(mathmlElement.children, name, flag);
-    });
   }
 
   private _hasFlag(flag: string): boolean {

--- a/src/data/usecases/mathml-to-latex-convertion/tree-to-latex.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/tree-to-latex.ts
@@ -1,0 +1,51 @@
+import { MathMLElement } from '../../protocols/mathml-element';
+import { MathMLElementToLatexConverterAdapter } from './mathml-element-to-latex-converter-adapter';
+import { setConversionMemo } from '../../helpers/mathml-element-to-latex-converter';
+
+// Converts a MathML element tree to LaTeX iteratively, using an explicit stack
+// instead of recursion so arbitrarily deep nesting cannot overflow the call
+// stack. Nodes are evaluated post-order (children before parents) and each
+// result is memoized; converters then read children's precomputed strings.
+export const convertTreeToLatex = (root: MathMLElement): string => {
+  annotateInnerTables(root);
+
+  const memo = new Map<MathMLElement, string>();
+  const stack: { node: MathMLElement; visited: boolean }[] = [{ node: root, visited: false }];
+  const previousMemo = setConversionMemo(memo);
+
+  try {
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+
+      if (!frame.visited) {
+        frame.visited = true;
+        const children = frame.node.children ?? [];
+        for (let i = children.length - 1; i >= 0; i--) stack.push({ node: children[i], visited: false });
+        continue;
+      }
+
+      stack.pop();
+      memo.set(frame.node, new MathMLElementToLatexConverterAdapter(frame.node).toLatexConverter().convert());
+    }
+  } finally {
+    setConversionMemo(previousMemo);
+  }
+
+  return memo.get(root) ?? '';
+};
+
+// Flags every mtable nested inside another mtable. This reproduces the
+// cumulative effect of the previous recursive per-converter flagging, but in a
+// single iterative top-down pass so it cannot overflow the call stack.
+const annotateInnerTables = (root: MathMLElement): void => {
+  const stack: { node: MathMLElement; insideMtable: boolean }[] = [{ node: root, insideMtable: false }];
+
+  while (stack.length > 0) {
+    const { node, insideMtable } = stack.pop() as { node: MathMLElement; insideMtable: boolean };
+    if (node.name === 'mtable' && insideMtable) node.attributes['innerTable'] = 'innerTable';
+
+    const childInsideMtable = insideMtable || node.name === 'mtable';
+    const children = node.children ?? [];
+    for (let i = 0; i < children.length; i++) stack.push({ node: children[i], insideMtable: childInsideMtable });
+  }
+};

--- a/src/infra/usecases/xmldom-to-mathml-elements/xmldom-elements-to-mathml-elements-adapter.ts
+++ b/src/infra/usecases/xmldom-to-mathml-elements/xmldom-elements-to-mathml-elements-adapter.ts
@@ -2,7 +2,27 @@ import { MathMLElement } from '../../../data/protocols/mathml-element';
 
 export class ElementsToMathMLAdapter {
   convert(els: Element[]): MathMLElement[] {
-    return els.filter((el: Element) => el.tagName !== undefined).map((el: Element) => this._convertElement(el));
+    const result: MathMLElement[] = [];
+    // Iterative depth-first build with an explicit stack, so deeply nested
+    // markup cannot overflow the call stack. Each node is linked into its
+    // parent's `children` array by reference; children are pushed in reverse so
+    // they are appended in document order.
+    const stack: { el: Element; target: MathMLElement[] }[] = [];
+    for (let i = els.length - 1; i >= 0; i--) stack.push({ el: els[i], target: result });
+
+    while (stack.length > 0) {
+      const { el, target } = stack.pop() as { el: Element; target: MathMLElement[] };
+      if (el.tagName === undefined) continue;
+
+      const node = this._convertElement(el);
+      target.push(node);
+
+      if (!this._hasElementChild(el)) continue;
+      const children = Array.from(el.childNodes) as Element[];
+      for (let i = children.length - 1; i >= 0; i--) stack.push({ el: children[i], target: node.children });
+    }
+
+    return result;
   }
 
   private _convertElement(el: Element): MathMLElement {
@@ -10,9 +30,7 @@ export class ElementsToMathMLAdapter {
       name: el.tagName,
       attributes: this._convertElementAttributes(el.attributes),
       value: this._hasElementChild(el) ? '' : el.textContent || '',
-      children: this._hasElementChild(el)
-        ? this.convert(Array.from(el.childNodes) as Element[])
-        : ([] as MathMLElement[]),
+      children: [],
     };
   }
 

--- a/src/main/mathml-to-latex.ts
+++ b/src/main/mathml-to-latex.ts
@@ -1,14 +1,11 @@
-import { MathMLElementToLatexConverterAdapter } from '../data/usecases/mathml-to-latex-convertion/mathml-element-to-latex-converter-adapter';
+import { convertTreeToLatex } from '../data/usecases/mathml-to-latex-convertion/tree-to-latex';
 import { makeToMathElementsConverter } from './factories';
 
 export class MathMLToLaTeX {
   static convert(mathml: string): string {
     const mathmlElements = makeToMathElementsConverter().convert(mathml);
-    const mathmlElementsToLaTeXConverters = mathmlElements.map((mathMLElement) =>
-      new MathMLElementToLatexConverterAdapter(mathMLElement).toLatexConverter(),
-    );
-    return mathmlElementsToLaTeXConverters
-      .map((toLatexConverters) => toLatexConverters.convert())
+    return mathmlElements
+      .map((mathMLElement) => convertTreeToLatex(mathMLElement))
       .join('')
       .trim();
   }


### PR DESCRIPTION
## Summary
Deeply nested MathML (e.g. thousands of nested `<mrow>`) overflowed the call stack with an uncontrolled `RangeError`, a denial-of-service vector when converting untrusted input. The conversion now runs fully iteratively, so arbitrarily deep nesting is converted instead of crashing (verified up to 200k levels).

## Changes
- Build the element tree iteratively with an explicit stack
- Add an iterative post-order driver (`tree-to-latex`) that memoizes each node's LaTeX; the converter helper returns precomputed child strings, so the ~25 converters stay unchanged and never recurse
- Hoist the `mtable` `innerTable` flagging into an iterative top-down pre-pass (removed the recursive call from `MTable`)
- Make `MFenced`'s relative lookup iterative
- Enable the previously skipped DoS robustness test

🤖 Generated with [Claude Code](https://claude.com/claude-code)