### PR TITLE
docs(project): add AGENTS.md and JSDoc across the codebase

### DIFF
--- a/.cursor/rules/typing.mdc
+++ b/.cursor/rules/typing.mdc
@@ -1,8 +1,0 @@
----
-description: 
-globs: 
-alwaysApply: true
----
-- Always place type/interface definition at the bottom of the file
-- Always place private methods below public ones
-- Unless necessary, place not exported code below the exported ones

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,134 @@
+# AGENTS.md
+
+Guidance for AI agents (and humans) working in this repository.
+
+## What this project is
+
+`mathml-to-latex` is a small, dependency-light TypeScript library that converts a
+[MathML](https://en.wikipedia.org/wiki/MathML) string into a
+[LaTeX](https://en.wikipedia.org/wiki/LaTeX) string. It is published to npm and
+bundled with webpack.
+
+The entire public API is a single static method:
+
+```ts
+import { MathMLToLaTeX } from 'mathml-to-latex';
+
+MathMLToLaTeX.convert('<math><mrow><mn>a</mn><mo>+</mo><mn>b</mn></mrow></math>');
+// => 'a + b'
+```
+
+`src/index.ts` exports **only** `MathMLToLaTeX`. Everything else is internal — do
+not widen the public surface without a deliberate reason.
+
+## Toolchain & commands
+
+- **Node:** `24.16.0`, pinned in `.tool-versions` (managed via `mise`/`asdf`).
+  Run commands through `mise exec node@24.16.0 -- <cmd>` if your shell default
+  differs.
+- **Install:** `npm ci`
+- **Test:** `npm test` (Jest + ts-jest; runs against `src`, no build needed)
+- **Test (watch / verbose):** `npm run test:watch`, `npm run test:verbose`
+- **Build:** `npm run build` (webpack → `dist/bundle.min.js` + `dist/index.d.ts`)
+- **Lint:** `npm run lint` (eslint + prettier, autofix)
+- **CI:** `.github/workflows/test.yml` runs the Dockerized test suite
+  (`make test-build && make test`) on every PR. Publishing
+  (`.github/workflows/publish.yml`) only happens on a GitHub **Release** — pushes
+  and merges never publish.
+
+## Architecture
+
+The code follows a layered (clean-architecture-ish) layout. Dependencies point
+inward: `main` → `data`/`infra` → `domain`.
+
+```
+src/
+  index.ts                     Public barrel (exports MathMLToLaTeX only)
+  main/                        Composition root
+    mathml-to-latex.ts         MathMLToLaTeX.convert — the public entry point
+    factories/                 Wiring (makeToMathElementsConverter)
+  domain/
+    usecases/to-latex-converter.ts   ToLaTeXConverter interface (the core contract)
+  data/
+    protocols/                 MathMLElement (internal tree node), UTF8 interface
+    usecases/mathml-to-latex-convertion/
+      mathml-element-to-latex-converter-adapter.ts  Tag name → converter registry
+      tree-to-latex.ts         Iterative post-order driver (tree → LaTeX)
+      converters/              One converter per MathML tag (mfrac, msup, mrow, …)
+    helpers/                   Wrappers, separators, whitespace, the memo helper
+    errors/                    Domain errors (InvalidNumberOfChildrenError)
+  infra/
+    usecases/xmldom-to-mathml-elements/   XML/DOM parsing (xmldom) → MathMLElement
+  syntax/                      Static lookup tables: unicode/glyph → LaTeX command
+```
+
+## The conversion pipeline
+
+`MathMLToLaTeX.convert(mathml)` runs two stages:
+
+1. **Parse → element tree** (`infra`): `XmlToMathMLAdapter` parses the string with
+   `@xmldom/xmldom`, cleaning MS Word artefacts (line breaks, `mml:` prefixes) and
+   recovering from malformed attributes via `ErrorHandler`.
+   `ElementsToMathMLAdapter` then maps the DOM into the internal
+   `MathMLElement` tree.
+2. **Tree → LaTeX** (`data`): for each top-level `<math>` element,
+   `convertTreeToLatex` walks the tree and produces LaTeX, dispatching each node
+   to its converter via `MathMLElementToLatexConverterAdapter`. Results are joined
+   and trimmed.
+
+`MathMLElement` is parser-agnostic on purpose: the conversion logic never touches
+DOM nodes, only this internal tree.
+
+## Design decisions worth knowing
+
+- **Everything is iterative, not recursive.** Both the DOM→tree build
+  (`ElementsToMathMLAdapter`) and the tree→LaTeX evaluation (`tree-to-latex`) use
+  explicit stacks so pathologically deep input cannot overflow the call stack
+  (a DoS vector). `tree-to-latex` evaluates **post-order** and memoizes each
+  node's LaTeX; the `mathMLElementToLaTeXConverter` helper returns a child's
+  precomputed string while a memo is active, so the ~25 converters can stay
+  written in their natural "combine my children's strings" style without ever
+  recursing deeply. If you add a converter, this just works — keep combining
+  children via the helper.
+- **`mtable` inner-table flag is a pre-pass.** Nested `<mtable>`s must be wrapped
+  in a `matrix` environment. Because evaluation is bottom-up but that flag is a
+  top-down property, `tree-to-latex` sets the `innerTable` flag in a separate
+  iterative top-down pass before evaluation. Don't move it back into a converter
+  constructor.
+- **Malformed-attribute recovery.** `ErrorHandler` repairs the value-less
+  attributes MS Word emits (e.g. `close= >`). xmldom 0.9 reports some of these as
+  a thrown `ParseError`, so `XmlToMathMLAdapter._parse` catches, lets the handler
+  fix the XML, and re-parses.
+
+## Adding a new MathML element converter
+
+1. Create `src/data/usecases/mathml-to-latex-convertion/converters/<tag>.ts` with
+   a class implementing `ToLaTeXConverter` (`convert(): string`). Combine child
+   LaTeX via `mathMLElementToLaTeXConverter(child).convert()`.
+2. Export it from `converters/index.ts`.
+3. Register the tag in the `fromMathMLElementToLatexConverter` map in
+   `mathml-element-to-latex-converter-adapter.ts`.
+4. Add cases to `__tests__` (see below).
+5. Throw `InvalidNumberOfChildrenError` for arity violations, matching the
+   existing converters (`mfrac`, `msup`, …).
+
+## Tests
+
+- Located in `__tests__/`; run with `npm test` (Jest, ts-jest, `--runInBand`).
+- `__tests__/index.test.ts` is the main integration suite (MathML string → LaTeX).
+- `__tests__/security/robustness.test.ts` covers parser hardening (deep nesting,
+  injection non-leakage).
+- Tests import from `src` directly — no build step required to run them.
+
+## Conventions
+
+- **All code and comments in English**, even in non-English conversations.
+- **Public/main functions first, private helpers at the bottom** of each file.
+- **Prefer early returns** over deep `if` nesting.
+- **Commits:** semantic style — `type(scope): short message` in English
+  (`feat`, `fix`, `refactor`, `test`, `chore`, `docs`). Keep messages short.
+- **Never `git add -A`/`git add .`** — stage specific files.
+- **Do not commit or push unless explicitly asked**; each commit/push needs its
+  own explicit go-ahead.
+- Don't add runtime dependencies lightly — the library ships with only
+  `@xmldom/xmldom`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,7 +123,9 @@ DOM nodes, only this internal tree.
 ## Conventions
 
 - **All code and comments in English**, even in non-English conversations.
-- **Public/main functions first, private helpers at the bottom** of each file.
+- **File layout:** exported/public code first, then private and non-exported
+  code; private methods go below public ones, and type/interface definitions go
+  at the bottom of the file.
 - **Prefer early returns** over deep `if` nesting.
 - **Commits:** semantic style — `type(scope): short message` in English
   (`feat`, `fix`, `refactor`, `test`, `chore`, `docs`). Keep messages short.

--- a/src/data/errors/invalid-number-of-children.ts
+++ b/src/data/errors/invalid-number-of-children.ts
@@ -1,4 +1,14 @@
+/**
+ * Thrown when a MathML element does not have the number of children its
+ * converter requires (e.g. `<mfrac>` needs exactly two).
+ */
 export class InvalidNumberOfChildrenError extends Error {
+  /**
+   * @param tagName - the offending element's tag name.
+   * @param expectedNumberOfChild - the number of children the converter expects.
+   * @param currentNumberOfChild - the number of children actually present.
+   * @param comparison - how to read the expectation (e.g. `exactly`, `at least`).
+   */
   constructor(tagName: string, expectedNumberOfChild: number, currentNumberOfChild: number, comparison = 'exactly') {
     super(
       `${tagName} tag must have ${comparison} ${expectedNumberOfChild} children. It's actually ${currentNumberOfChild}`,

--- a/src/data/helpers/join-with-many-separators.ts
+++ b/src/data/helpers/join-with-many-separators.ts
@@ -1,3 +1,9 @@
+/**
+ * Joins a list of strings using a list of separators, one per gap. When there
+ * are more gaps than separators the last separator is reused; when no
+ * separators are given, `defaultSeparator` is used. Used by `<mfenced>` to honor
+ * its `separators` attribute.
+ */
 export class JoinWithManySeparators {
   private _separators: string[];
 
@@ -5,6 +11,12 @@ export class JoinWithManySeparators {
     this._separators = separators;
   }
 
+  /**
+   * @param arr - the strings to join.
+   * @param separators - the separators to place between items, in order.
+   * @param defaultSeparator - separator used when `separators` is empty.
+   * @returns the joined string.
+   */
   static join(arr: string[], separators: string[], defaultSeparator: string = ''): string {
     const effectiveSeparators =
       separators.length > 0 ? separators : defaultSeparator !== undefined ? [defaultSeparator] : [];

--- a/src/data/helpers/mathml-element-to-latex-converter.ts
+++ b/src/data/helpers/mathml-element-to-latex-converter.ts
@@ -8,12 +8,27 @@ import { MathMLElementToLatexConverterAdapter } from '../usecases/mathml-to-late
 // a converter that would recurse — keeping the call stack flat at any depth.
 let conversionMemo: Map<MathMLElement, string> | null = null;
 
+/**
+ * Activates (or clears, with `null`) the memo consulted by
+ * {@link mathMLElementToLaTeXConverter}.
+ *
+ * @param memo - the memo to make active, or `null` to disable memoization.
+ * @returns the previously active memo, so callers can restore it afterwards.
+ */
 export const setConversionMemo = (memo: Map<MathMLElement, string> | null): Map<MathMLElement, string> | null => {
   const previous = conversionMemo;
   conversionMemo = memo;
   return previous;
 };
 
+/**
+ * Resolves the {@link ToLaTeXConverter} for an element. While a memo is active
+ * and already contains the element, returns a converter that yields the
+ * precomputed LaTeX (no recursion); otherwise builds the real converter.
+ *
+ * @param mathMLElement - the element to convert.
+ * @returns a converter bound to the element.
+ */
 export const mathMLElementToLaTeXConverter = (mathMLElement: MathMLElement): ToLaTeXConverter => {
   const precomputed = conversionMemo?.get(mathMLElement);
   if (precomputed !== undefined) return new PrecomputedConverter(precomputed);

--- a/src/data/helpers/normalize-whitespace.ts
+++ b/src/data/helpers/normalize-whitespace.ts
@@ -1,3 +1,9 @@
+/**
+ * Collapses every run of whitespace in the string into a single space.
+ *
+ * @param str - the string to normalize.
+ * @returns the string with runs of whitespace reduced to single spaces.
+ */
 export const normalizeWhiteSpaces = (str: string): string => {
   return str.replace(/\s+/g, ' ');
 };

--- a/src/data/helpers/wrappers/bracket.ts
+++ b/src/data/helpers/wrappers/bracket.ts
@@ -1,9 +1,14 @@
 import { Wrapper } from './wrapper';
 
+/**
+ * Wraps a string in LaTeX curly braces (`{ ... }`), e.g. for subscript and
+ * superscript arguments.
+ */
 export class BracketWrapper {
   protected _open = '{';
   protected _close = '}';
 
+  /** @returns `str` wrapped in curly braces. */
   wrap(str: string): string {
     return new Wrapper(this._open, this._close).wrap(str);
   }

--- a/src/data/helpers/wrappers/generic.ts
+++ b/src/data/helpers/wrappers/generic.ts
@@ -1,5 +1,9 @@
 import { Wrapper } from './wrapper';
 
+/**
+ * Wraps a string with auto-sizing LaTeX delimiters, prefixing the given
+ * open/close characters with `\left` and `\right` (e.g. `\left( ... \right)`).
+ */
 export class GenericWrapper {
   protected _open: string;
   protected _close: string;
@@ -9,6 +13,7 @@ export class GenericWrapper {
     this._close = '\\right' + close;
   }
 
+  /** @returns `str` wrapped in `\left`/`\right` delimiters. */
   wrap(str: string): string {
     return new Wrapper(this._open, this._close).wrap(str);
   }

--- a/src/data/helpers/wrappers/parenthesis.ts
+++ b/src/data/helpers/wrappers/parenthesis.ts
@@ -1,13 +1,18 @@
 import { Wrapper } from './wrapper';
 
+/**
+ * Wraps a string in auto-sizing LaTeX parentheses (`\left( ... \right)`).
+ */
 export class ParenthesisWrapper {
   protected _open = '\\left(';
   protected _close = '\\right)';
 
+  /** @returns `str` wrapped in `\left(`/`\right)`. */
   wrap(str: string): string {
     return new Wrapper(this._open, this._close).wrap(str);
   }
 
+  /** @returns `str` wrapped in parentheses only when it is longer than one char. */
   wrapIfMoreThanOneChar(str: string): string {
     if (str.length <= 1) return str;
     return this.wrap(str);

--- a/src/data/helpers/wrappers/wrapper.ts
+++ b/src/data/helpers/wrappers/wrapper.ts
@@ -1,3 +1,6 @@
+/**
+ * Base helper that surrounds a string with an opening and a closing delimiter.
+ */
 export class Wrapper {
   protected _open: string;
   protected _close: string;
@@ -7,6 +10,7 @@ export class Wrapper {
     this._close = close;
   }
 
+  /** @returns `str` surrounded by the configured open/close delimiters. */
   wrap(str: string): string {
     return this._open + str + this._close;
   }

--- a/src/data/protocols/mathml-element.ts
+++ b/src/data/protocols/mathml-element.ts
@@ -1,10 +1,23 @@
+/**
+ * Internal, parser-agnostic representation of a MathML node. The whole library
+ * works on this tree rather than on DOM nodes, so the conversion logic is
+ * decoupled from the XML parser.
+ */
 export interface MathMLElement {
+  /** Tag name of the element (e.g. `mrow`, `mfrac`, `mi`). */
   readonly name: string;
+  /** Text content of a leaf element; empty for elements that have children. */
   readonly value: string;
+  /** Child elements, in document order. */
   readonly children: MathMLElement[];
+  /** Element attributes as a plain map; mutable so the pipeline can flag nodes. */
   attributes: Record<string, string>;
 }
 
+/**
+ * Null-object {@link MathMLElement} used as a safe fallback when no element is
+ * available, so converters never have to guard against `null`/`undefined`.
+ */
 export class VoidMathMLElement implements MathMLElement {
   readonly name = 'void';
   readonly value = '';

--- a/src/data/usecases/mathml-to-latex-convertion/converters/generic-spacing-wrapper.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/generic-spacing-wrapper.ts
@@ -2,6 +2,16 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers';
 
+/**
+ * Fallback converter that recursively converts every child and joins the
+ * results with single spaces.
+ *
+ * Used for container-like MathML elements that have no special LaTeX rendering
+ * of their own and simply pass their children through.
+ *
+ * @example
+ * // <mtd><mi>a</mi><mo>+</mo><mi>b</mi></mtd> -> a + b
+ */
 export class GenericSpacingWrapper implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +19,9 @@ export class GenericSpacingWrapper implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     return this._mathmlElement.children
       .map((child) => mathMLElementToLaTeXConverter(child))

--- a/src/data/usecases/mathml-to-latex-convertion/converters/generic-under-over.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/generic-under-over.ts
@@ -4,6 +4,16 @@ import { mathMLElementToLaTeXConverter } from '../../../helpers/mathml-element-t
 import { InvalidNumberOfChildrenError } from '../../../errors';
 import { latexAccents } from '../../../../syntax/latex-accents';
 
+/**
+ * Converts a MathML `<mover>` or `<munder>` element into LaTeX.
+ *
+ * Converts the base and the accent, then either applies the accent as a LaTeX
+ * accent command (when it is a known accent) or wraps it with `\overset`/
+ * `\underset` depending on whether the element name contains `under`.
+ *
+ * @example
+ * // <munder><mi>x</mi><mo>+</mo></munder> -> \underset{+}{x}
+ */
 export class GenericUnderOver implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -11,6 +21,10 @@ export class GenericUnderOver implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   * @throws {InvalidNumberOfChildrenError} when the element does not have exactly 2 children.
+   */
   convert(): string {
     const { name, children } = this._mathmlElement;
     const childrenLength = children.length;
@@ -23,6 +37,7 @@ export class GenericUnderOver implements ToLaTeXConverter {
     return this._applyCommand(content, accent);
   }
 
+  /** Chooses the under/over command based on the element name and applies it to the content and accent. */
   private _applyCommand(content: string, accent: string): string {
     const type = this._mathmlElement.name.match(/under/) ? TagTypes.Under : TagTypes.Over;
     return new UnderOverSetter(type).apply(content, accent);

--- a/src/data/usecases/mathml-to-latex-convertion/converters/maction.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/maction.ts
@@ -2,6 +2,15 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers/mathml-element-to-latex-converter';
 
+/**
+ * Converts a MathML `<maction>` element into LaTeX.
+ *
+ * For toggle actions (or when `actiontype` is absent) it joins all child
+ * conversions with `\Longrightarrow`; otherwise it converts only the first child.
+ *
+ * @example
+ * // <maction actiontype="toggle"><mi>a</mi><mi>b</mi></maction> -> a \Longrightarrow b
+ */
 export class MAction implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +18,9 @@ export class MAction implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const { children } = this._mathmlElement;
 
@@ -21,6 +33,7 @@ export class MAction implements ToLaTeXConverter {
     return mathMLElementToLaTeXConverter(children[0]).convert();
   }
 
+  /** True when the action is a toggle, i.e. `actiontype` is 'toggle' or unset. */
   private _isToggle(): boolean {
     const { actiontype } = this._mathmlElement.attributes;
     return actiontype === 'toggle' || !actiontype;

--- a/src/data/usecases/mathml-to-latex-convertion/converters/math.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/math.ts
@@ -3,6 +3,15 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers/mathml-element-to-latex-converter';
 import { normalizeWhiteSpaces } from '../../../helpers/normalize-whitespace';
 
+/**
+ * Converts a MathML `<math>` root element into LaTeX.
+ *
+ * Recursively converts every child to LaTeX, joins the results with spaces
+ * and normalizes the resulting whitespace.
+ *
+ * @example
+ * // <math><mi>x</mi><mo>=</mo><mn>1</mn></math> -> x = 1
+ */
 export class Math implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +19,9 @@ export class Math implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const unnormalizedLatex = this._mathmlElement.children
       .map((child) => mathMLElementToLaTeXConverter(child))

--- a/src/data/usecases/mathml-to-latex-convertion/converters/menclose.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/menclose.ts
@@ -2,6 +2,16 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers/mathml-element-to-latex-converter';
 
+/**
+ * Converts a MathML `<menclose>` element into LaTeX.
+ *
+ * Recursively converts its children and wraps them in the LaTeX construct that
+ * matches the `notation` attribute (e.g. radical, box, strike), defaulting to a
+ * long-division style overline when `notation` is absent or unrecognized.
+ *
+ * @example
+ * // <menclose notation="radical"><mi>x</mi></menclose> -> \sqrt{x}
+ */
 export class MEnclose implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +19,9 @@ export class MEnclose implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const latexJoinedChildren = this._mathmlElement.children
       .map((child) => mathMLElementToLaTeXConverter(child))
@@ -32,6 +45,7 @@ export class MEnclose implements ToLaTeXConverter {
     return `\\overline{\\left.\\right)${latexJoinedChildren}}`;
   }
 
+  /** Returns the `notation` attribute, defaulting to 'longdiv'. */
   private get _notation(): string {
     return this._mathmlElement.attributes.notation || 'longdiv';
   }

--- a/src/data/usecases/mathml-to-latex-convertion/converters/merror.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/merror.ts
@@ -2,6 +2,15 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers/mathml-element-to-latex-converter';
 
+/**
+ * Converts a MathML `<merror>` element into LaTeX.
+ *
+ * Recursively converts its children, joins them with spaces, and wraps the
+ * result in a red `\color` group.
+ *
+ * @example
+ * // <merror><mi>x</mi></merror> -> \color{red}{x}
+ */
 export class MError implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +18,9 @@ export class MError implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const latexJoinedChildren = this._mathmlElement.children
       .map((child) => mathMLElementToLaTeXConverter(child))

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mfenced.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mfenced.ts
@@ -3,6 +3,16 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers/mathml-element-to-latex-converter';
 import { GenericWrapper, JoinWithManySeparators } from '../../../helpers';
 
+/**
+ * Converts a MathML `<mfenced>` element into LaTeX delimited content.
+ *
+ * Children are converted and either wrapped as a matrix (when a descendant
+ * `<mtable>` is present, picking the environment from the open/close fences) or
+ * joined with the `separators`/`open`/`close` attributes as a delimited vector.
+ *
+ * @example
+ * // <mfenced open="(" close=")"><mi>a</mi><mi>b</mi></mfenced> -> \left(a,b\right)
+ */
 export class MFenced implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
   private readonly open: string;
@@ -14,6 +24,9 @@ export class MFenced implements ToLaTeXConverter {
     this.close = this._mathmlElement.attributes.close || '';
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const latexChildren = this._mathmlElement.children
       .map((child) => mathMLElementToLaTeXConverter(child))
@@ -31,6 +44,7 @@ export class MFenced implements ToLaTeXConverter {
     return new Vector(this.open, this.close, separatorsArray, defaultSeparator).apply(latexChildren);
   }
 
+  /** Depth-first searches the subtree for any descendant element with the given name. */
   private _isThereRelativeOfName(mathmlElements: MathMLElement[], elementName: string): boolean {
     // Iterative depth-first search so a deeply nested subtree cannot overflow
     // the call stack.

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mfrac.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mfrac.ts
@@ -3,6 +3,18 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { InvalidNumberOfChildrenError } from '../../../errors';
 import { ParenthesisWrapper, mathMLElementToLaTeXConverter } from '../../../helpers';
 
+/**
+ * Converts a MathML `<mfrac>` element into a LaTeX fraction.
+ *
+ * Produces `\frac{numerator}{denominator}`, or the bevelled form
+ * `numerator/denominator` (each side wrapped in parentheses when longer than one
+ * character) when the `bevelled` attribute is set.
+ *
+ * @example
+ * // <mfrac><mn>1</mn><mn>2</mn></mfrac> -> \frac{1}{2}
+ * @example
+ * // <mfrac bevelled="true"><mn>1</mn><mn>2</mn></mfrac> -> 1/2
+ */
 export class MFrac implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +22,10 @@ export class MFrac implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   * @throws {InvalidNumberOfChildrenError} if the element does not have exactly 2 children.
+   */
   convert(): string {
     const { children, name } = this._mathmlElement;
     const childrenLength = children.length;
@@ -24,10 +40,12 @@ export class MFrac implements ToLaTeXConverter {
     return `\\frac{${num}}{${den}}`;
   }
 
+  /** Wraps the bevelled-fraction side in parentheses when it is longer than one character. */
   private _wrapIfMoreThanOneChar(str: string): string {
     return new ParenthesisWrapper().wrapIfMoreThanOneChar(str);
   }
 
+  /** Whether the `bevelled` attribute requests the inline `a/b` form. */
   private _isBevelled(): boolean {
     return !!this._mathmlElement.attributes.bevelled;
   }

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mi.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mi.ts
@@ -5,6 +5,15 @@ import { allMathSymbolsByChar, allMathSymbolsByGlyph, mathNumberByGlyph } from '
 import { UTF8ToLtXConverter } from 'data/protocols';
 import { HashUTF8ToLtXConverter } from '../../../../syntax/utf8-converter';
 
+/**
+ * Converts a MathML `<mi>` (identifier) element into LaTeX.
+ *
+ * Maps known math symbols/glyphs to their LaTeX commands (falling back to UTF-8
+ * conversion), then wraps the result according to the `mathvariant` attribute.
+ *
+ * @example
+ * // <mi mathvariant="bold">x</mi> -> \mathbf{x}
+ */
 export class MI implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -14,6 +23,9 @@ export class MI implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const normalizedValue = normalizeWhiteSpaces(this._mathmlElement.value);
     if (normalizedValue === ' ') return Character.apply(normalizedValue);
@@ -27,11 +39,13 @@ export class MI implements ToLaTeXConverter {
     return this.wrapInMathVariant(convertedChar, this.getMathVariant(this._mathmlElement.attributes));
   }
 
+  /** Extracts the `mathvariant` attribute value, or undefined when absent. */
   private getMathVariant(attributes: Record<string, unknown> | undefined) {
     if (!attributes || !attributes.mathvariant) return undefined;
     return attributes.mathvariant as string;
   }
 
+  /** Wraps the value in the LaTeX font command matching the given `mathvariant`. */
   private wrapInMathVariant(value: string, mathVariant: string | undefined) {
     switch (mathVariant) {
       case 'bold':
@@ -66,6 +80,7 @@ export class MI implements ToLaTeXConverter {
   }
 }
 
+/** Resolves a single identifier value to its LaTeX command via symbol lookup tables, falling back to UTF-8 conversion. */
 class Character {
   private _value: string;
 

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mmultiscripts.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mmultiscripts.ts
@@ -3,6 +3,15 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter, ParenthesisWrapper } from '../../../helpers';
 import { InvalidNumberOfChildrenError } from '../../../errors';
 
+/**
+ * Converts a MathML `<mmultiscripts>` element into LaTeX.
+ *
+ * Renders the base with attached subscript/superscript pairs, honoring an
+ * optional `<mprescripts>` marker to emit pre-scripts before the base.
+ *
+ * @example
+ * // <mmultiscripts><mi>X</mi><mn>1</mn><mn>2</mn></mmultiscripts> -> X_{1}^{2}
+ */
 export class MMultiscripts implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +19,10 @@ export class MMultiscripts implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   * @throws {InvalidNumberOfChildrenError} when fewer than 3 children are present.
+   */
   convert(): string {
     const { name, children } = this._mathmlElement;
     const childrenLength = children.length;
@@ -21,6 +34,7 @@ export class MMultiscripts implements ToLaTeXConverter {
     return this._prescriptLatex() + this._wrapInParenthesisIfThereIsSpace(baseContent) + this._postscriptLatex();
   }
 
+  /** Builds the pre-script `_{...}^{...}` segment when an `<mprescripts>` marker is present. */
   private _prescriptLatex(): string {
     const { children } = this._mathmlElement;
     let sub;
@@ -40,6 +54,7 @@ export class MMultiscripts implements ToLaTeXConverter {
     return `\\_{${subLatex}}^{${supLatex}}`;
   }
 
+  /** Builds the post-script `_{...}^{...}` segment that follows the base. */
   private _postscriptLatex(): string {
     const { children } = this._mathmlElement;
     if (this._isPrescripts(children[1])) return '';
@@ -53,11 +68,13 @@ export class MMultiscripts implements ToLaTeXConverter {
     return `_{${subLatex}}^{${supLatex}}`;
   }
 
+  /** Wraps the base in parentheses when it contains whitespace, to keep scripts attached correctly. */
   private _wrapInParenthesisIfThereIsSpace(str: string): string {
     if (!str.match(/\s+/g)) return str;
     return new ParenthesisWrapper().wrap(str);
   }
 
+  /** Returns true when the child is the `<mprescripts>` marker element. */
   private _isPrescripts(child: MathMLElement): boolean {
     return child?.name === 'mprescripts';
   }

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mn.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mn.ts
@@ -3,6 +3,15 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { normalizeWhiteSpaces } from '../../../helpers';
 import { mathNumberByGlyph } from '../../../../syntax';
 
+/**
+ * Converts a MathML `<mn>` (number) element into LaTeX.
+ *
+ * Normalizes/trims the value and maps it through the number-by-glyph table,
+ * returning the raw normalized value when no mapping exists.
+ *
+ * @example
+ * // <mn>42</mn> -> 42
+ */
 export class MN implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +19,9 @@ export class MN implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const normalizedValue = normalizeWhiteSpaces(this._mathmlElement.value).trim();
     const convertedValue = mathNumberByGlyph[normalizedValue];

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mo.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mo.ts
@@ -8,6 +8,15 @@ import {
   mathNumberByGlyph,
 } from '../../../../syntax';
 
+/**
+ * Converts a MathML `<mo>` (operator) element into LaTeX.
+ *
+ * Normalizes/trims the value and resolves it to a LaTeX command through the
+ * operator lookup tables, falling back to UTF-8 conversion.
+ *
+ * @example
+ * // <mo>&#x2211;</mo> -> \sum
+ */
 export class MO implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -15,6 +24,9 @@ export class MO implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const normalizedValue = normalizeWhiteSpaces(this._mathmlElement.value);
     const trimmedValue = normalizedValue.trim();
@@ -23,6 +35,7 @@ export class MO implements ToLaTeXConverter {
   }
 }
 
+/** Resolves a single operator value to its LaTeX command via operator lookup tables, falling back to UTF-8 conversion. */
 class Operator {
   private _value: string;
 

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mphantom.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mphantom.ts
@@ -1,6 +1,15 @@
 import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter';
 import { MathMLElement } from '../../../protocols/mathml-element';
 
+/**
+ * Converts a MathML `<mphantom>` element into LaTeX.
+ *
+ * The element reserves layout space without rendering content, so it produces
+ * an empty string.
+ *
+ * @example
+ * // <mphantom>x</mphantom> -> ''
+ */
 export class MPhantom implements ToLaTeXConverter {
   private readonly _mathmlElement;
 
@@ -8,6 +17,9 @@ export class MPhantom implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     return '';
   }

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mroot.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mroot.ts
@@ -3,6 +3,15 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers';
 import { InvalidNumberOfChildrenError } from '../../../errors';
 
+/**
+ * Converts a MathML `<mroot>` element into a LaTeX n-th root.
+ *
+ * Converts the first child as the radicand and the second child as the index,
+ * producing `\sqrt[index]{content}`.
+ *
+ * @example
+ * // <mroot><mn>8</mn><mn>3</mn></mroot> -> \sqrt[3]{8}
+ */
 export class MRoot implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +19,10 @@ export class MRoot implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   * @throws {InvalidNumberOfChildrenError} if the element does not have exactly 2 children.
+   */
   convert(): string {
     const { name, children } = this._mathmlElement;
     const childrenLength = children.length;

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mrow.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mrow.ts
@@ -2,6 +2,19 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers';
 
+/**
+ * Converts a MathML `<mrow>` grouping element into LaTeX.
+ *
+ * By default it recursively converts every child and joins the results with
+ * spaces. As a special case, when the row matches the linear-system pattern
+ * (an opening `{` operator, an `<mtable>`, and an empty closing operator) it is
+ * rendered as a LaTeX `cases` environment.
+ *
+ * @example
+ * // <mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow> -> a + b
+ * @example
+ * // <mrow><mo>{</mo><mtable>...</mtable><mo></mo></mrow> -> \begin{cases} ... \end{cases}
+ */
 export class MRow implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +22,9 @@ export class MRow implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     // Check if this is a linear system pattern: { + mtable + empty closing operator
     if (this._isLinearSystemPattern()) {
@@ -21,6 +37,7 @@ export class MRow implements ToLaTeXConverter {
       .join(' ');
   }
 
+  /** Detects the `{` + `<mtable>` + empty closing operator shape used for linear systems. */
   private _isLinearSystemPattern(): boolean {
     const { children } = this._mathmlElement;
 
@@ -41,6 +58,7 @@ export class MRow implements ToLaTeXConverter {
     return isOpeningBrace && isMTable && isEmptyClosing;
   }
 
+  /** Renders the inner `<mtable>` rows as a LaTeX `cases` environment. */
   private _convertAsLinearSystem(): string {
     const mtableChild = this._mathmlElement.children[1];
     const tableContent = mtableChild.children

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mspace.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mspace.ts
@@ -1,6 +1,14 @@
 import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter';
 import { MathMLElement } from '../../../protocols/mathml-element';
 
+/**
+ * Converts a MathML `<mspace>` element into LaTeX.
+ *
+ * Emits a LaTeX line break when `linebreak="newline"`, otherwise a single space.
+ *
+ * @example
+ * // <mspace linebreak="newline" /> ->  \\
+ */
 export class MSpace implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -8,6 +16,9 @@ export class MSpace implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const { linebreak } = this._mathmlElement.attributes;
 

--- a/src/data/usecases/mathml-to-latex-convertion/converters/msqrt.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/msqrt.ts
@@ -2,6 +2,15 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers';
 
+/**
+ * Converts a MathML `<msqrt>` element into a LaTeX square root.
+ *
+ * Recursively converts every child, joins the results with spaces and wraps
+ * them in `\sqrt{...}`.
+ *
+ * @example
+ * // <msqrt><mn>2</mn></msqrt> -> \sqrt{2}
+ */
 export class MSqrt implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +18,9 @@ export class MSqrt implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const latexJoinedChildren = this._mathmlElement.children
       .map((child) => mathMLElementToLaTeXConverter(child))

--- a/src/data/usecases/mathml-to-latex-convertion/converters/msub.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/msub.ts
@@ -3,6 +3,16 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter, ParenthesisWrapper, BracketWrapper } from '../../../helpers';
 import { InvalidNumberOfChildrenError } from '../../../errors';
 
+/**
+ * Converts a MathML `<msub>` element into a LaTeX subscript.
+ *
+ * Produces `base_{subscript}`. The base is parenthesized when it has more than
+ * one child (and is longer than one character); the subscript is always wrapped
+ * in braces.
+ *
+ * @example
+ * // <msub><mi>x</mi><mn>1</mn></msub> -> x_{1}
+ */
 export class MSub implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +20,10 @@ export class MSub implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   * @throws {InvalidNumberOfChildrenError} if the element does not have exactly 2 children.
+   */
   convert(): string {
     const { name, children } = this._mathmlElement;
     const childrenLength = children.length;
@@ -22,6 +36,7 @@ export class MSub implements ToLaTeXConverter {
     return `${this._handleBaseChild(baseChild)}_${this._handleSubscriptChild(subscriptChild)}`;
   }
 
+  /** Converts the base, parenthesizing it when it groups more than one child. */
   private _handleBaseChild(base: MathMLElement): string {
     const baseChildren = base.children;
     const baseStr = mathMLElementToLaTeXConverter(base).convert();
@@ -33,6 +48,7 @@ export class MSub implements ToLaTeXConverter {
     return new ParenthesisWrapper().wrapIfMoreThanOneChar(baseStr);
   }
 
+  /** Converts the subscript and wraps it in braces. */
   private _handleSubscriptChild(subscript: MathMLElement): string {
     const subscriptStr = mathMLElementToLaTeXConverter(subscript).convert();
 

--- a/src/data/usecases/mathml-to-latex-convertion/converters/msubsup.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/msubsup.ts
@@ -3,6 +3,16 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter, ParenthesisWrapper, BracketWrapper } from '../../../helpers';
 import { InvalidNumberOfChildrenError } from '../../../errors';
 
+/**
+ * Converts a MathML `<msubsup>` element into a combined LaTeX subscript and superscript.
+ *
+ * Produces `base_{subscript}^{superscript}`. The base is parenthesized when it
+ * has more than one child (and is longer than one character); both the subscript
+ * and superscript are always wrapped in braces.
+ *
+ * @example
+ * // <msubsup><mi>x</mi><mn>1</mn><mn>2</mn></msubsup> -> x_{1}^{2}
+ */
 export class MSubsup implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +20,10 @@ export class MSubsup implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   * @throws {InvalidNumberOfChildrenError} if the element does not have exactly 3 children.
+   */
   convert(): string {
     const { name, children } = this._mathmlElement;
     const childrenLength = children.length;
@@ -23,6 +37,7 @@ export class MSubsup implements ToLaTeXConverter {
     return `${this._handleBaseChild(baseChild)}_${this._handleSubscriptChild(subscriptChild)}^${this._handleSuperscriptChild(superscriptChild)}`;
   }
 
+  /** Converts the base, parenthesizing it when it groups more than one child. */
   private _handleBaseChild(base: MathMLElement): string {
     const baseChildren = base.children;
     const baseStr = mathMLElementToLaTeXConverter(base).convert();
@@ -34,12 +49,14 @@ export class MSubsup implements ToLaTeXConverter {
     return new ParenthesisWrapper().wrapIfMoreThanOneChar(baseStr);
   }
 
+  /** Converts the subscript and wraps it in braces. */
   private _handleSubscriptChild(subscript: MathMLElement): string {
     const subscriptStr = mathMLElementToLaTeXConverter(subscript).convert();
 
     return new BracketWrapper().wrap(subscriptStr);
   }
 
+  /** Converts the superscript and wraps it in braces. */
   private _handleSuperscriptChild(superscript: MathMLElement): string {
     const superscriptStr = mathMLElementToLaTeXConverter(superscript).convert();
 

--- a/src/data/usecases/mathml-to-latex-convertion/converters/msup.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/msup.ts
@@ -3,6 +3,16 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter, ParenthesisWrapper, BracketWrapper } from '../../../helpers';
 import { InvalidNumberOfChildrenError } from '../../../errors';
 
+/**
+ * Converts a MathML `<msup>` element into a LaTeX superscript.
+ *
+ * Produces `base^{exponent}`. The base is parenthesized when it has more than
+ * one child (and is longer than one character); the exponent is always wrapped
+ * in braces.
+ *
+ * @example
+ * // <msup><mi>x</mi><mn>2</mn></msup> -> x^{2}
+ */
 export class MSup implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +20,10 @@ export class MSup implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   * @throws {InvalidNumberOfChildrenError} if the element does not have exactly 2 children.
+   */
   convert(): string {
     const { name, children } = this._mathmlElement;
     const childrenLength = children.length;
@@ -22,6 +36,7 @@ export class MSup implements ToLaTeXConverter {
     return `${this._handleBaseChild(baseChild)}^${this._handleExponentChild(exponentChild)}`;
   }
 
+  /** Converts the base, parenthesizing it when it groups more than one child. */
   private _handleBaseChild(base: MathMLElement): string {
     const baseChildren = base.children;
     const baseStr = mathMLElementToLaTeXConverter(base).convert();
@@ -33,6 +48,7 @@ export class MSup implements ToLaTeXConverter {
     return new ParenthesisWrapper().wrapIfMoreThanOneChar(baseStr);
   }
 
+  /** Converts the exponent and wraps it in braces. */
   private _handleExponentChild(exponent: MathMLElement): string {
     const exponentStr = mathMLElementToLaTeXConverter(exponent).convert();
 

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mtable.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mtable.ts
@@ -2,6 +2,16 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers';
 
+/**
+ * Converts a MathML `<mtable>` element into LaTeX matrix rows.
+ *
+ * Each row child is converted and the results are joined with `\\` row
+ * separators. When the element carries the `innerTable` flag (set by the
+ * tree pre-pass) the rows are additionally wrapped in a `matrix` environment.
+ *
+ * @example
+ * // <mtable><mtr><mtd><mn>1</mn></mtd></mtr></mtable> -> 1
+ */
 export class MTable implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +19,9 @@ export class MTable implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const tableContent = this._mathmlElement.children
       .map((child) => mathMLElementToLaTeXConverter(child))
@@ -19,10 +32,12 @@ export class MTable implements ToLaTeXConverter {
     return this._hasFlag('innerTable') ? this._wrap(tableContent) : tableContent;
   }
 
+  /** Wraps the rows in a `matrix` environment. */
   private _wrap(latex: string): string {
     return `\\begin{matrix}${latex}\\end{matrix}`;
   }
 
+  /** Checks whether the given boolean flag attribute is present and truthy. */
   private _hasFlag(flag: string): boolean {
     return !!this._mathmlElement.attributes[flag];
   }

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mtext.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mtext.ts
@@ -2,6 +2,16 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { MI } from './mi';
 
+/**
+ * Converts a MathML `<mtext>` element into LaTeX.
+ *
+ * Splits the text into runs of alphanumeric/space characters and standalone
+ * symbols: alphanumeric runs are wrapped by the `mathvariant` text command while
+ * each symbol is delegated to the `<mi>` converter.
+ *
+ * @example
+ * // <mtext mathvariant="bold">hi</mtext> -> \textbf{hi}
+ */
 export class MText implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +19,9 @@ export class MText implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     const { attributes, value } = this._mathmlElement;
 
@@ -55,6 +68,7 @@ export class MText implements ToLaTeXConverter {
   }
 }
 
+/** Wraps a text value in the LaTeX text/font command(s) matching the given `mathvariant`. */
 class TextCommand {
   private readonly _mathvariant: string;
 

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mtr.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mtr.ts
@@ -2,6 +2,15 @@ import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers';
 
+/**
+ * Converts a MathML `<mtr>` (table row) element into LaTeX.
+ *
+ * Each cell child is converted and the results are joined with the `&` column
+ * separator used inside LaTeX matrix environments.
+ *
+ * @example
+ * // <mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr> -> 1 & 2
+ */
 export class MTr implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -9,6 +18,9 @@ export class MTr implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     return this._mathmlElement.children
       .map((child) => mathMLElementToLaTeXConverter(child))

--- a/src/data/usecases/mathml-to-latex-convertion/converters/munderover.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/munderover.ts
@@ -3,6 +3,15 @@ import { MathMLElement } from '../../../protocols/mathml-element';
 import { mathMLElementToLaTeXConverter } from '../../../helpers';
 import { InvalidNumberOfChildrenError } from '../../../errors';
 
+/**
+ * Converts a MathML `<munderover>` element into LaTeX under/over scripts.
+ *
+ * Converts the three children as base, under-content and over-content,
+ * producing `base_{under}^{over}`.
+ *
+ * @example
+ * // <munderover><mo>∑</mo><mi>i</mi><mi>n</mi></munderover> -> \sum_{i}^{n}
+ */
 export class MUnderover implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
 
@@ -10,6 +19,10 @@ export class MUnderover implements ToLaTeXConverter {
     this._mathmlElement = mathElement;
   }
 
+  /**
+   * @returns the LaTeX representation of this element.
+   * @throws {InvalidNumberOfChildrenError} if the element does not have exactly 3 children.
+   */
   convert(): string {
     const { name, children } = this._mathmlElement;
     const childrenLength = children.length;

--- a/src/data/usecases/mathml-to-latex-convertion/converters/void.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/void.ts
@@ -1,8 +1,19 @@
 import { ToLaTeXConverter } from 'domain/usecases/to-latex-converter';
 
+/**
+ * No-op converter for MathML elements that have no LaTeX representation.
+ *
+ * Always produces an empty string, used as a fallback/placeholder converter.
+ *
+ * @example
+ * // any element -> ''
+ */
 export class Void implements ToLaTeXConverter {
   constructor(private readonly _mathmlElement: MathMLElement) {}
 
+  /**
+   * @returns the LaTeX representation of this element.
+   */
   convert(): string {
     return '';
   }

--- a/src/data/usecases/mathml-to-latex-convertion/mathml-element-to-latex-converter-adapter.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/mathml-element-to-latex-converter-adapter.ts
@@ -2,6 +2,11 @@ import * as ToLatexConverters from './converters';
 import { MathMLElement, VoidMathMLElement } from '../../../data/protocols/mathml-element';
 import { ToLaTeXConverter, ToLaTeXConverterClass } from '../../../domain/usecases/to-latex-converter';
 
+/**
+ * Maps a {@link MathMLElement} to the concrete {@link ToLaTeXConverter} that
+ * knows how to render it, based on the element's tag name. Unknown tags fall
+ * back to the generic spacing wrapper that simply joins the children.
+ */
 export class MathMLElementToLatexConverterAdapter {
   private readonly _mathMLElement: MathMLElement;
 
@@ -9,6 +14,7 @@ export class MathMLElementToLatexConverterAdapter {
     this._mathMLElement = mathMLElement ?? new VoidMathMLElement();
   }
 
+  /** @returns a converter instance bound to the wrapped element. */
   toLatexConverter(): ToLaTeXConverter {
     const { name } = this._mathMLElement;
     const Converter = fromMathMLElementToLatexConverter[name] || ToLatexConverters.GenericSpacingWrapper;
@@ -17,6 +23,7 @@ export class MathMLElementToLatexConverterAdapter {
   }
 }
 
+/** Registry mapping each supported MathML tag name to its converter class. */
 const fromMathMLElementToLatexConverter: Record<string, ToLaTeXConverterClass> = {
   math: ToLatexConverters.Math,
   mi: ToLatexConverters.MI,

--- a/src/data/usecases/mathml-to-latex-convertion/tree-to-latex.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/tree-to-latex.ts
@@ -2,10 +2,16 @@ import { MathMLElement } from '../../protocols/mathml-element';
 import { MathMLElementToLatexConverterAdapter } from './mathml-element-to-latex-converter-adapter';
 import { setConversionMemo } from '../../helpers/mathml-element-to-latex-converter';
 
-// Converts a MathML element tree to LaTeX iteratively, using an explicit stack
-// instead of recursion so arbitrarily deep nesting cannot overflow the call
-// stack. Nodes are evaluated post-order (children before parents) and each
-// result is memoized; converters then read children's precomputed strings.
+/**
+ * Converts a MathML element tree to LaTeX iteratively, using an explicit stack
+ * instead of recursion so arbitrarily deep nesting cannot overflow the call
+ * stack. Nodes are evaluated post-order (children before parents) and each
+ * result is memoized; converters then read their children's precomputed strings
+ * through {@link mathMLElementToLaTeXConverter} instead of recursing.
+ *
+ * @param root - the root element of the tree to convert.
+ * @returns the LaTeX string for the whole tree.
+ */
 export const convertTreeToLatex = (root: MathMLElement): string => {
   annotateInnerTables(root);
 

--- a/src/domain/usecases/to-latex-converter.ts
+++ b/src/domain/usecases/to-latex-converter.ts
@@ -1,7 +1,16 @@
+/**
+ * Common contract implemented by every element converter: turn the wrapped
+ * MathML element into a LaTeX string.
+ */
 export interface ToLaTeXConverter {
+  /** @returns the LaTeX representation of the wrapped element. */
   convert(): string;
 }
 
+/**
+ * Constructor signature of a {@link ToLaTeXConverter}, used by the dispatcher to
+ * instantiate the right converter for a given MathML element.
+ */
 export interface ToLaTeXConverterClass {
   new (...args: any): ToLaTeXConverter;
 }

--- a/src/infra/usecases/xmldom-to-mathml-elements/error-handler.ts
+++ b/src/infra/usecases/xmldom-to-mathml-elements/error-handler.ts
@@ -1,6 +1,21 @@
+/**
+ * Recovers from the malformed-attribute errors commonly produced by MS Word
+ * exports (e.g. `<mfenced open='{' close= >`). It inspects the parser error
+ * message and rewrites the offending value-less attribute out of the XML so the
+ * markup can be re-parsed successfully.
+ */
 export class ErrorHandler {
   private _errors: string[] = [];
 
+  /**
+   * If the parser error is a recoverable missing-attribute-value error, records
+   * it and returns the XML with the offending attribute stripped; otherwise
+   * returns the XML unchanged.
+   *
+   * @param xml - the current (possibly malformed) XML.
+   * @param errorMessage - the message reported by the parser.
+   * @returns the (possibly corrected) XML.
+   */
   fixError(xml: string, errorMessage: string): string {
     if (!this._isMissingAttributeValueError(errorMessage)) return xml;
 
@@ -47,7 +62,7 @@ export class ErrorHandler {
       errorMessage.includes('attribute value missed') ||
       // Since xmldom 0.9 a value-less attribute written as `attr=` is reported
       // as this fatalError instead of a recoverable warning.
-      errorMessage.includes("AttValue: ' or \" expected")
+      errorMessage.includes('AttValue: \' or " expected')
     );
   }
 }

--- a/src/infra/usecases/xmldom-to-mathml-elements/xmldom-elements-to-mathml-elements-adapter.ts
+++ b/src/infra/usecases/xmldom-to-mathml-elements/xmldom-elements-to-mathml-elements-adapter.ts
@@ -1,6 +1,17 @@
 import { MathMLElement } from '../../../data/protocols/mathml-element';
 
+/**
+ * Maps parsed DOM {@link Element}s into the library's internal
+ * {@link MathMLElement} tree. The mapping is iterative (explicit stack) so very
+ * deeply nested markup cannot overflow the call stack.
+ */
 export class ElementsToMathMLAdapter {
+  /**
+   * Builds {@link MathMLElement} trees from the given DOM elements.
+   *
+   * @param els - the root DOM elements to convert (e.g. the `<math>` elements).
+   * @returns the corresponding internal element trees, in document order.
+   */
   convert(els: Element[]): MathMLElement[] {
     const result: MathMLElement[] = [];
     // Iterative depth-first build with an explicit stack, so deeply nested

--- a/src/infra/usecases/xmldom-to-mathml-elements/xmldom-to-mathml-element-adapter.ts
+++ b/src/infra/usecases/xmldom-to-mathml-elements/xmldom-to-mathml-element-adapter.ts
@@ -3,6 +3,14 @@ import { ElementsToMathMLAdapter } from './xmldom-elements-to-mathml-elements-ad
 import { ErrorHandler } from './error-handler';
 import { MathMLElement } from '../../../data/protocols/mathml-element';
 
+/**
+ * Parses a MathML/XML string into an array of internal {@link MathMLElement}
+ * trees (one per `<math>` element).
+ *
+ * It cleans up MS Word artefacts (line breaks, `mml:` prefixes), tolerates
+ * malformed attributes through {@link ErrorHandler}, and delegates the DOM →
+ * {@link MathMLElement} mapping to {@link ElementsToMathMLAdapter}.
+ */
 export class XmlToMathMLAdapter {
   private _xml = '';
   private readonly _xmlDOM: DOMParser;
@@ -20,6 +28,12 @@ export class XmlToMathMLAdapter {
     });
   }
 
+  /**
+   * Parses the given markup and returns its `<math>` elements as trees.
+   *
+   * @param xml - the MathML/XML markup to parse.
+   * @returns one {@link MathMLElement} tree per `<math>` element found.
+   */
   convert(xml: string): MathMLElement[] {
     this._xml = this._removeLineBreaks(xml);
     this._xml = this._removeMsWordPrefixes(this._xml);

--- a/src/main/factories/make-to-math-elements-converter.ts
+++ b/src/main/factories/make-to-math-elements-converter.ts
@@ -4,6 +4,12 @@ import {
   ErrorHandler,
 } from '../../infra/usecases/xmldom-to-mathml-elements';
 
+/**
+ * Wires up and returns the parser that turns a MathML string into element
+ * trees, with its element mapper and error handler.
+ *
+ * @returns a ready-to-use {@link XmlToMathMLAdapter}.
+ */
 export const makeToMathElementsConverter = (): XmlToMathMLAdapter => {
   const elementsToMathMLAdapter = new ElementsToMathMLAdapter();
   const errorHandler = new ErrorHandler();

--- a/src/main/mathml-to-latex.ts
+++ b/src/main/mathml-to-latex.ts
@@ -1,7 +1,24 @@
 import { convertTreeToLatex } from '../data/usecases/mathml-to-latex-convertion/tree-to-latex';
 import { makeToMathElementsConverter } from './factories';
 
+/**
+ * Public entry point of the library: converts a MathML string into LaTeX.
+ *
+ * The conversion runs in two stages — the MathML is parsed into an internal
+ * element tree (see {@link makeToMathElementsConverter}), then each top-level
+ * element tree is converted to LaTeX iteratively (see {@link convertTreeToLatex}).
+ *
+ * @example
+ * MathMLToLaTeX.convert('<math><mrow><mn>a</mn><mo>+</mo><mn>b</mn></mrow></math>');
+ * // => 'a + b'
+ */
 export class MathMLToLaTeX {
+  /**
+   * Converts a MathML string to its LaTeX representation.
+   *
+   * @param mathml - the MathML markup to convert.
+   * @returns the equivalent LaTeX string (trimmed).
+   */
   static convert(mathml: string): string {
     const mathmlElements = makeToMathElementsConverter().convert(mathml);
     return mathmlElements

--- a/src/syntax/all-math-operators-by-char.ts
+++ b/src/syntax/all-math-operators-by-char.ts
@@ -1,3 +1,8 @@
+/**
+ * Lookup table mapping math operators, keyed by their literal HTML character
+ * reference (e.g. `&#x2211;`), to the equivalent LaTeX command. Consumed by the
+ * `<mo>` converter to translate operator content into LaTeX.
+ */
 export const allMathOperatorsByChar: Record<string, string> = {
   _: '\\underline',
   '&#x23E1;': '\\underbrace',

--- a/src/syntax/all-math-operators-by-glyph.ts
+++ b/src/syntax/all-math-operators-by-glyph.ts
@@ -1,3 +1,8 @@
+/**
+ * Lookup table mapping math operators, keyed by their decoded unicode glyph
+ * (e.g. `∑`), to the equivalent LaTeX command. Consumed by the `<mo>` converter
+ * to translate operator content into LaTeX.
+ */
 export const allMathOperatorsByGlyph: Record<string, string> = {
   _: '\\underline',
   '⏡': '\\underbrace',

--- a/src/syntax/all-math-symbols-by-char.ts
+++ b/src/syntax/all-math-symbols-by-char.ts
@@ -1,3 +1,8 @@
+/**
+ * Lookup table mapping math symbols, keyed by their literal HTML character
+ * reference (e.g. `&#x2200;`), to the equivalent LaTeX command. Consumed by the
+ * `<mi>`/`<mo>` converters to translate symbol content into LaTeX.
+ */
 export const allMathSymbolsByChar: Record<string, string> = {
   '&#xA0;': '\\textrm{ }',
   '&#x2203;': '\\exists',

--- a/src/syntax/all-math-symbols-by-glyph.ts
+++ b/src/syntax/all-math-symbols-by-glyph.ts
@@ -1,3 +1,8 @@
+/**
+ * Lookup table mapping math symbols, keyed by their decoded unicode glyph
+ * (e.g. `∀`), to the equivalent LaTeX command. Consumed by the `<mi>`/`<mo>`
+ * converters to translate symbol content into LaTeX.
+ */
 export const allMathSymbolsByGlyph: Record<string, string> = {
   ' ': '\\textrm{ }',
   '∃': '\\exists',

--- a/src/syntax/latex-accents.ts
+++ b/src/syntax/latex-accents.ts
@@ -1,1 +1,6 @@
+/**
+ * List of LaTeX accent commands that wrap their argument directly (e.g.
+ * `\hat{x}`). Consumed by the under/over converters to decide whether an accent
+ * should be applied as a command rather than via `\overset`/`\underset`.
+ */
 export const latexAccents = ['\\hat', '\\bar', '\\underbrace', '\\overbrace'];

--- a/src/syntax/math-numbers-by-glyph.ts
+++ b/src/syntax/math-numbers-by-glyph.ts
@@ -1,3 +1,8 @@
+/**
+ * Lookup table mapping unicode sub/superscript digit glyphs (e.g. `₀`, `⁰`),
+ * keyed by glyph, to their LaTeX subscript/superscript form. Consumed by the
+ * `<mi>`/`<mn>` converters to translate numeric script glyphs into LaTeX.
+ */
 export const mathNumberByGlyph: Record<string, string> = {
   '₀': '_{0}',
   '₁': '_{1}',


### PR DESCRIPTION
## Summary
Documents the whole project: adds an `AGENTS.md` contributor guide and JSDoc comments across the codebase. Comments only — no behavior change (659 tests pass, build unchanged).

## Changes
- **AGENTS.md** — project overview, toolchain/commands, layered architecture and directory map, the two-stage conversion pipeline, key design decisions (iterative traversal, mtable flag pre-pass, malformed-attribute recovery), how to add a converter, and conventions
- **JSDoc** on the public API, domain interfaces, protocols, the parsing adapters, the iterative driver, helpers and errors
- **JSDoc** on all ~25 element converters (class purpose + `@example` + `@returns`/`@throws`)
- **File headers** on the `syntax/` lookup tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)