### PR TITLE
fix(converters): guard lookup tables against prototype-chain keys

### DIFF
--- a/__tests__/security/robustness.test.ts
+++ b/__tests__/security/robustness.test.ts
@@ -70,4 +70,24 @@ describe('#convert security and robustness', () => {
       expect(MathMLToLaTeX.convert(mathml)).toBe('1');
     });
   });
+
+  describe('given element text that collides with Object.prototype keys', () => {
+    // The symbol/operator lookup tables are plain object literals, so a token
+    // such as "constructor" or "toString" resolves through the prototype chain
+    // instead of missing. An unknown token must instead fall through to its
+    // literal text, exactly like any other unrecognized token (e.g. "foo").
+    const prototypeKeys = ['constructor', 'hasOwnProperty', 'toString', 'valueOf', '__proto__'];
+
+    it.each(prototypeKeys)('converts <mo>%s</mo> to its literal text', (token) => {
+      const result = MathMLToLaTeX.convert(`<math><mo>${token}</mo></math>`);
+
+      expect(result).toBe(token);
+      expect(result).not.toContain('[native code]');
+    });
+
+    it.each(prototypeKeys)('converts <mi>%s</mi> to its literal text', (token) => {
+      expect(() => MathMLToLaTeX.convert(`<math><mi>${token}</mi></math>`)).not.toThrow();
+      expect(MathMLToLaTeX.convert(`<math><mi>${token}</mi></math>`)).toBe(token);
+    });
+  });
 });

--- a/src/data/helpers/index.ts
+++ b/src/data/helpers/index.ts
@@ -2,3 +2,4 @@ export * from './wrappers';
 export * from './join-with-many-separators';
 export * from './mathml-element-to-latex-converter';
 export * from './normalize-whitespace';
+export * from './own-lookup';

--- a/src/data/helpers/own-lookup.ts
+++ b/src/data/helpers/own-lookup.ts
@@ -1,0 +1,13 @@
+/**
+ * Looks a key up in a lookup table, returning `undefined` for keys that are not
+ * own properties (e.g. `constructor`, `toString`, `__proto__`) instead of
+ * resolving them through the object's prototype chain. This keeps element text
+ * that happens to collide with `Object.prototype` members from leaking
+ * unexpected values into the output.
+ *
+ * @param table - the lookup table.
+ * @param key - the key to look up.
+ * @returns the mapped value, or `undefined` when the key is not an own property.
+ */
+export const ownLookup = <T>(table: Record<string, T>, key: string): T | undefined =>
+  Object.prototype.hasOwnProperty.call(table, key) ? table[key] : undefined;

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mi.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mi.ts
@@ -1,6 +1,6 @@
 import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter';
 import { MathMLElement } from '../../../protocols/mathml-element';
-import { normalizeWhiteSpaces } from '../../../helpers';
+import { normalizeWhiteSpaces, ownLookup } from '../../../helpers';
 import { allMathSymbolsByChar, allMathSymbolsByGlyph, mathNumberByGlyph } from '../../../../syntax';
 import { UTF8ToLtXConverter } from 'data/protocols';
 import { HashUTF8ToLtXConverter } from '../../../../syntax/utf8-converter';
@@ -102,14 +102,14 @@ class Character {
   }
 
   private _findByCharacter(): string | undefined {
-    return allMathSymbolsByChar[this._value];
+    return ownLookup(allMathSymbolsByChar, this._value);
   }
 
   private _findByGlyph(): string | undefined {
-    return allMathSymbolsByGlyph[this._value];
+    return ownLookup(allMathSymbolsByGlyph, this._value);
   }
 
   private _findByNumber(): string | undefined {
-    return mathNumberByGlyph[this._value];
+    return ownLookup(mathNumberByGlyph, this._value);
   }
 }

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mn.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mn.ts
@@ -1,6 +1,6 @@
 import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter';
 import { MathMLElement } from '../../../protocols/mathml-element';
-import { normalizeWhiteSpaces } from '../../../helpers';
+import { normalizeWhiteSpaces, ownLookup } from '../../../helpers';
 import { mathNumberByGlyph } from '../../../../syntax';
 
 /**
@@ -24,7 +24,7 @@ export class MN implements ToLaTeXConverter {
    */
   convert(): string {
     const normalizedValue = normalizeWhiteSpaces(this._mathmlElement.value).trim();
-    const convertedValue = mathNumberByGlyph[normalizedValue];
+    const convertedValue = ownLookup(mathNumberByGlyph, normalizedValue);
 
     return convertedValue || normalizedValue;
   }

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mo.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mo.ts
@@ -1,6 +1,6 @@
 import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter';
 import { MathMLElement } from '../../../protocols/mathml-element';
-import { normalizeWhiteSpaces } from '../../../helpers';
+import { normalizeWhiteSpaces, ownLookup } from '../../../helpers';
 import {
   HashUTF8ToLtXConverter,
   allMathOperatorsByChar,
@@ -57,14 +57,14 @@ class Operator {
   }
 
   private _findByCharacter(): string | undefined {
-    return allMathOperatorsByChar[this._value];
+    return ownLookup(allMathOperatorsByChar, this._value);
   }
 
   private _findByGlyph(): string | undefined {
-    return allMathOperatorsByGlyph[this._value];
+    return ownLookup(allMathOperatorsByGlyph, this._value);
   }
 
   private _findByNumber(): string | undefined {
-    return mathNumberByGlyph[this._value];
+    return ownLookup(mathNumberByGlyph, this._value);
   }
 }


### PR DESCRIPTION
## Summary
The symbol/operator lookup tables are plain object literals, so element text that collides with `Object.prototype` keys resolved through the prototype chain instead of missing. This was reachable from the public API:

- `<mo>constructor</mo>` returned `"function Object() { [native code] }"`
- `<mi>toString</mi>` threw `TypeError: char.match is not a function`

Such tokens now fall through to their literal text, like any other unrecognized token.

## Changes
- Add an `ownLookup` helper that only returns own-property matches (`undefined` for prototype keys)
- Use it for the `<mo>`, `<mi>` and `<mn>` table lookups
- Add tests covering `constructor`, `hasOwnProperty`, `toString`, `valueOf`, `__proto__` for both `<mo>` and `<mi>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)