### PR TITLE
chore(ci): bump docker/publish node to 24.16.0 and alpine to 3.23

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,11 +8,13 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        node-version: [22.x]
+        node-version: [24.x]
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Dependencies installation
         run: npm install

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM node:22.11.0-alpine3.20
+FROM node:24.16.0-alpine3.23
 WORKDIR /usr/src/mathml-to-latex
 RUN npm -g i npm
 COPY ./package*.json ./


### PR DESCRIPTION
## Summary
The CI Docker image and the publish workflow were still on Node 22, out of sync with the `24.16.0` pinned in `.tool-versions`. This aligns them.

## Changes
- `Dockerfile.test`: `node:22.11.0-alpine3.20` → `node:24.16.0-alpine3.23` (node and alpine bumped)
- `publish.yml`: matrix `22.x` → `24.x`, and wire `node-version` into `setup-node` (it was previously ignored, so the matrix had no effect)

🤖 Generated with [Claude Code](https://claude.com/claude-code)