### PR TITLE
chore(deps): upgrade to typescript 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "prettier": "3.8.3",
         "ts-jest": "^29.4.11",
         "ts-loader": "^9.6.0",
-        "typescript": "^5.9.3",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.1",
         "webpack": "^5.107.2",
         "webpack-cli": "^7.0.3"
@@ -6818,9 +6818,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "3.8.3",
     "ts-jest": "^29.4.11",
     "ts-loader": "^9.6.0",
-    "typescript": "^5.9.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1",
     "webpack": "^5.107.2",
     "webpack-cli": "^7.0.3"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,17 @@
 {
   "compilerOptions": {
-    "baseUrl": "src",
+    "paths": {
+      "data/*": ["./src/data/*"],
+      "domain/*": ["./src/domain/*"]
+    },
     "outDir": "dist",
     "target": "es2015",
     "module": "commonjs",
     "esModuleInterop": true,
     "strict": true,
     "rootDir": "src",
-    "lib": ["es2015", "dom"],
+    "types": ["jest"],
+    "lib": ["es2017", "dom"],
     "sourceMap": true,
     "declaration": true
   },


### PR DESCRIPTION
## Summary
Upgrades TypeScript 5 → 6 and modernizes `tsconfig.json` accordingly — without keeping any deprecated option and without converting imports to relative paths.

## Changes
- `typescript` 5.9.3 → 6.0.3
- Replace the now-deprecated `baseUrl` with a modern `paths` mapping (`data/*`, `domain/*` → `./src/*`), keeping the existing non-relative imports
- Bump `lib` `es2015` → `es2017` (the code uses `Array.prototype.includes`, which is ES2016)
- Add `types: ["jest"]` — TS 6 changed automatic `@types` inclusion for files outside `include`, so the test globals (`describe`/`it`/`expect`) had to be declared explicitly; scoped to `jest` only so the build stays free of `@types/node` (unused by `src`)

`target` is intentionally kept at `es2015` to preserve the published bundle's compatibility.

## Verification
- `tsc --noEmit`, build (webpack + ts-loader), the 669 tests and lint all pass
- published `dist/*.d.ts` reference neither `jest` nor `@types/node`

🤖 Generated with [Claude Code](https://claude.com/claude-code)