### PR TITLE
docs(readme): document ESM, CommonJS and UMD formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,26 @@ MathMLToLaTeX.convert(mathml);
 // => A = \begin{bmatrix} x & y \\ z & w \end{bmatrix}
 ```
 
+## Module formats
+
+The package ships in three formats, so it works the same in modern bundlers, Node and the browser. TypeScript declarations are bundled in, so no extra `@types` package is needed.
+
+- **ES Modules** — for bundlers (webpack, Vite, Rollup…) and modern Node:
+
+  ```javascript
+  import { MathMLToLaTeX } from 'mathml-to-latex';
+  ```
+
+- **CommonJS** — for Node's `require`:
+
+  ```javascript
+  const { MathMLToLaTeX } = require('mathml-to-latex');
+  ```
+
+- **UMD** — a self-contained, minified bundle for direct use in the browser via a `<script>` tag / CDN (see [Browser](#browser) below).
+
+The right format is selected automatically through the package's `exports` map.
+
 ## Browser
 
 Package is also available directly in the browser through CDN:


### PR DESCRIPTION
## Summary
Documents the module formats the package now ships (ESM, CommonJS, UMD) after the Rollup migration.

## Changes
- Add a "Module formats" section to the README covering:
  - ES Modules for bundlers and modern Node
  - CommonJS for `require`
  - UMD for the browser via `<script>`/CDN
  - a note that TypeScript declarations are bundled in and the format is picked automatically via the `exports` map

🤖 Generated with [Claude Code](https://claude.com/claude-code)