### PR TITLE
chore(release): bump version to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mathml-to-latex",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mathml-to-latex",
-      "version": "1.5.0",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathml-to-latex",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "A JavaScript tool to convert mathml string to LaTeX string",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Minor release bumping `1.5.0` → `1.6.0`.

## Changes
- Dual ESM + CJS package with conditional `exports` (native ESM, tree-shaking, correct `import`/`require` resolution)
- Iterative MathML traversal (removes recursion stack-overflow risk on deep inputs)
- Prototype-key lookup fix
- `@xmldom/xmldom` upgraded to `^0.9.10`

Public API (`MathMLToLaTeX.convert`), TypeScript types, and the UMD global are unchanged — minor, non-breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)