### PR TITLE
feat(delimiters): pair vertical bars into mfenced

### DIFF
--- a/src/data/helpers/wrappers/generic.test.ts
+++ b/src/data/helpers/wrappers/generic.test.ts
@@ -12,4 +12,8 @@ describe('GenericWrapper', () => {
   ])('escapes a $name to a valid LaTeX delimiter (issue #66)', ({ open, close, latex }) => {
     expect(new GenericWrapper(open, close).wrap('x')).toBe(latex);
   });
+
+  it('maps a double bar to the norm delimiter', () => {
+    expect(new GenericWrapper('||', '||').wrap('x')).toBe('\\left\\|x\\right\\|');
+  });
 });

--- a/src/data/helpers/wrappers/generic.ts
+++ b/src/data/helpers/wrappers/generic.ts
@@ -18,15 +18,19 @@ export class GenericWrapper {
     return new Wrapper(this._open, this._close).wrap(str);
   }
 
-  /**
-   * Maps a MathML fence character to a valid `\left`/`\right` delimiter:
-   * braces are grouping characters so a bare `{`/`}` must be escaped to `\{`/`\}`,
-   * and a double bar `||` is the norm delimiter `\|` (a bare `\left||` would be a
-   * stretchy bar followed by a literal one).
-   */
+  /** Maps a MathML fence character to its valid `\left`/`\right` delimiter form. */
   private _toLatexDelimiter(delimiter: string): string {
-    if (delimiter === '{' || delimiter === '}') return '\\' + delimiter;
-    if (delimiter === '||') return '\\|';
-    return delimiter;
+    return DELIMITER_TRANSLATIONS.get(delimiter) ?? delimiter;
   }
 }
+
+/**
+ * MathML fence characters that are not valid `\left`/`\right` delimiters as-is:
+ * braces are grouping characters (need `\{`/`\}`) and a double bar is the norm
+ * delimiter `\|` (a bare `\left||` is a stretchy bar followed by a literal one).
+ */
+const DELIMITER_TRANSLATIONS = new Map([
+  ['{', '\\{'],
+  ['}', '\\}'],
+  ['||', '\\|'],
+]);

--- a/src/data/helpers/wrappers/generic.ts
+++ b/src/data/helpers/wrappers/generic.ts
@@ -9,8 +9,8 @@ export class GenericWrapper {
   protected _close: string;
 
   constructor(open: string, close: string) {
-    this._open = '\\left' + this._escapeDelimiter(open);
-    this._close = '\\right' + this._escapeDelimiter(close);
+    this._open = '\\left' + this._toLatexDelimiter(open);
+    this._close = '\\right' + this._toLatexDelimiter(close);
   }
 
   /** @returns `str` wrapped in `\left`/`\right` delimiters. */
@@ -19,11 +19,14 @@ export class GenericWrapper {
   }
 
   /**
-   * Braces are grouping characters in LaTeX, so a bare `{`/`}` is not a valid
-   * `\left`/`\right` delimiter. They must be escaped to `\{`/`\}`.
+   * Maps a MathML fence character to a valid `\left`/`\right` delimiter:
+   * braces are grouping characters so a bare `{`/`}` must be escaped to `\{`/`\}`,
+   * and a double bar `||` is the norm delimiter `\|` (a bare `\left||` would be a
+   * stretchy bar followed by a literal one).
    */
-  private _escapeDelimiter(delimiter: string): string {
+  private _toLatexDelimiter(delimiter: string): string {
     if (delimiter === '{' || delimiter === '}') return '\\' + delimiter;
+    if (delimiter === '||') return '\\|';
     return delimiter;
   }
 }

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.integration.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.integration.test.ts
@@ -64,9 +64,30 @@ describe('normalize-fences (integration)', () => {
       latex: '\\left(a\\right) \\left|\\right. b',
     },
     {
-      name: 'double bars are left untouched',
+      name: 'a matched double bar pair (norm) renders with \\| delimiters',
       mathml: '<math><mrow><mo>||</mo><mi>a</mi><mo>||</mo></mrow></math>',
-      latex: '\\left||\\right. a \\left||\\right.',
+      latex: '\\left\\|a\\right\\|',
+    },
+    {
+      name: 'a double bar pair around a table becomes a Vmatrix',
+      mathml: `
+<math>
+  <mrow>
+    <mo>||</mo>
+    <mtable>
+      <mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr>
+      <mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr>
+    </mtable>
+    <mo>||</mo>
+  </mrow>
+</math>
+`,
+      latex: '\\begin{Vmatrix} 1 & 2 \\\\ 3 & 4 \\end{Vmatrix}',
+    },
+    {
+      name: 'an unmatched double bar stays a valid self-balanced norm delimiter',
+      mathml: '<math><mrow><mo>(</mo><mi>a</mi><mo>)</mo><mo>||</mo><mi>b</mi></mrow></math>',
+      latex: '\\left(a\\right) \\left\\|\\right. b',
     },
     {
       // A single separator bar (divides, such-that, evaluated-at) never pairs,

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.integration.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.integration.test.ts
@@ -33,6 +33,57 @@ describe('normalize-fences (integration)', () => {
       latex: '\\left(\\right. a',
     },
     {
+      name: 'a matched vertical bar pair (absolute value)',
+      mathml: '<math><mrow><mo>|</mo><mi>x</mi><mo>|</mo></mrow></math>',
+      latex: '\\left|x\\right|',
+    },
+    {
+      name: 'consecutive bar pairs do not cross',
+      mathml: '<math><mrow><mo>|</mo><mi>a</mi><mo>|</mo><mo>+</mo><mo>|</mo><mi>b</mi><mo>|</mo></mrow></math>',
+      latex: '\\left|a\\right| + \\left|b\\right|',
+    },
+    {
+      name: 'a bar pair around a table becomes a vmatrix (determinant)',
+      mathml: `
+<math>
+  <mrow>
+    <mo>|</mo>
+    <mtable>
+      <mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr>
+      <mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr>
+    </mtable>
+    <mo>|</mo>
+  </mrow>
+</math>
+`,
+      latex: '\\begin{vmatrix} 1 & 2 \\\\ 3 & 4 \\end{vmatrix}',
+    },
+    {
+      name: 'an odd vertical bar stays self-balanced',
+      mathml: '<math><mrow><mo>(</mo><mi>a</mi><mo>)</mo><mo>|</mo><mi>b</mi></mrow></math>',
+      latex: '\\left(a\\right) \\left|\\right. b',
+    },
+    {
+      name: 'double bars are left untouched',
+      mathml: '<math><mrow><mo>||</mo><mi>a</mi><mo>||</mo></mrow></math>',
+      latex: '\\left||\\right. a \\left||\\right.',
+    },
+    {
+      // A single separator bar (divides, such-that, evaluated-at) never pairs,
+      // so it stays exactly as it converts today.
+      name: 'a lone separator bar stays untouched',
+      mathml: '<math><mrow><mi>a</mi><mo>|</mo><mi>b</mi></mrow></math>',
+      latex: 'a \\left|\\right. b',
+    },
+    {
+      // Known limitation: an even count of separator bars in one row is paired
+      // positionally (toggle), so such-that-style "x | y | z" gets a bar pair
+      // around y. It still renders as bars, matching pre-existing behavior.
+      name: 'an even count of separator bars is paired (known limitation)',
+      mathml: '<math><mrow><mi>x</mi><mo>|</mo><mi>y</mi><mo>|</mo><mi>z</mi></mrow></math>',
+      latex: 'x \\left|y\\right| z',
+    },
+    {
       name: 'bare parentheses around a table become a pmatrix',
       mathml: `
 <math>

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.test.ts
@@ -122,12 +122,33 @@ describe('FenceNormalizer', () => {
     expect(outerBar.children[0]).toMatchObject({ name: 'mfenced', attributes: { open: '(', close: ')' } });
   });
 
-  it('leaves double bars untouched', () => {
+  it('pairs a matched double bar pair (norm)', () => {
     const root = parent([mo('||'), mi('a'), mo('||')]);
 
     new FenceNormalizer(root).normalize();
 
-    expect(root.children.map((c) => `${c.name}:${c.value}`)).toEqual(['mo:||', 'mi:a', 'mo:||']);
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0]).toMatchObject({ name: 'mfenced', attributes: { open: '||', close: '||' } });
+    expect(root.children[0].children[0]).toMatchObject({ name: 'mi', value: 'a' });
+  });
+
+  it('does not cross single and double bars when improperly nested', () => {
+    const root = parent([mo('|'), mi('a'), mo('||'), mi('b'), mo('|')]);
+
+    new FenceNormalizer(root).normalize();
+
+    // A bar only closes a same-glyph bar on top, so nothing here pairs.
+    expect(root.children.map((c) => `${c.name}:${c.value}`)).toEqual(['mo:|', 'mi:a', 'mo:||', 'mi:b', 'mo:|']);
+  });
+
+  it('nests a single bar pair inside a double bar pair', () => {
+    const root = parent([mo('||'), mo('|'), mi('x'), mo('|'), mo('||')]);
+
+    new FenceNormalizer(root).normalize();
+
+    const outer = root.children[0];
+    expect(outer).toMatchObject({ name: 'mfenced', attributes: { open: '||', close: '||' } });
+    expect(outer.children[0]).toMatchObject({ name: 'mfenced', attributes: { open: '|', close: '|' } });
   });
 
   it('descends into nested elements', () => {

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.test.ts
@@ -74,12 +74,60 @@ describe('FenceNormalizer', () => {
     expect(root.children.map((c) => `${c.name}:${c.value}`)).toEqual(['mi:a', 'mo:)']);
   });
 
-  it('leaves vertical bars untouched', () => {
+  it('pairs a matched vertical bar pair (absolute value)', () => {
     const root = parent([mo('|'), mi('a'), mo('|')]);
 
     new FenceNormalizer(root).normalize();
 
-    expect(root.children.map((c) => `${c.name}:${c.value}`)).toEqual(['mo:|', 'mi:a', 'mo:|']);
+    expect(root.children).toHaveLength(1);
+    expect(root.children[0]).toMatchObject({ name: 'mfenced', attributes: { open: '|', close: '|' } });
+    expect(root.children[0].children[0]).toMatchObject({ name: 'mi', value: 'a' });
+  });
+
+  it('toggles bars so consecutive pairs do not cross (|a| + |b|)', () => {
+    const root = parent([mo('|'), mi('a'), mo('|'), mo('+'), mo('|'), mi('b'), mo('|')]);
+
+    new FenceNormalizer(root).normalize();
+
+    expect(root.children.map((c) => `${c.name}:${c.attributes.open ?? c.value}`)).toEqual([
+      'mfenced:|',
+      'mo:+',
+      'mfenced:|',
+    ]);
+  });
+
+  it('leaves an odd (unmatched) bar self-balanced', () => {
+    const root = parent([mo('|'), mi('a'), mo('|'), mi('b'), mo('|')]);
+
+    new FenceNormalizer(root).normalize();
+
+    expect(root.children.map((c) => `${c.name}:${c.attributes.open ?? c.value}`)).toEqual([
+      'mfenced:|',
+      'mi:b',
+      'mo:|',
+    ]);
+  });
+
+  it('nests a bar pair inside parentheses and vice versa', () => {
+    const parens = parent([mo('('), mo('|'), mi('x'), mo('|'), mo(')')]);
+    new FenceNormalizer(parens).normalize();
+    const outer = parens.children[0];
+    expect(outer).toMatchObject({ name: 'mfenced', attributes: { open: '(', close: ')' } });
+    expect(outer.children[0]).toMatchObject({ name: 'mfenced', attributes: { open: '|', close: '|' } });
+
+    const bars = parent([mo('|'), mo('('), mi('x'), mo(')'), mo('|')]);
+    new FenceNormalizer(bars).normalize();
+    const outerBar = bars.children[0];
+    expect(outerBar).toMatchObject({ name: 'mfenced', attributes: { open: '|', close: '|' } });
+    expect(outerBar.children[0]).toMatchObject({ name: 'mfenced', attributes: { open: '(', close: ')' } });
+  });
+
+  it('leaves double bars untouched', () => {
+    const root = parent([mo('||'), mi('a'), mo('||')]);
+
+    new FenceNormalizer(root).normalize();
+
+    expect(root.children.map((c) => `${c.name}:${c.value}`)).toEqual(['mo:||', 'mi:a', 'mo:||']);
   });
 
   it('descends into nested elements', () => {

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.ts
@@ -14,9 +14,11 @@ import { MathMLElement } from '../../protocols/mathml-element';
  *
  * Pairing is positional (a closer matches the nearest open fence) and may mix
  * types (`(` with `]`), which `<mfenced>` renders as valid asymmetric
- * delimiters. Only parentheses, square brackets and braces participate; vertical
- * bars are ambiguous (same glyph on both sides) and are left untouched, as is
- * any fence that does not find a match.
+ * delimiters. Parentheses, square brackets and braces are directional. Vertical
+ * bars (`|`) share one glyph for both sides, so they toggle: a bar opens a pair
+ * unless one is already open at the current level, in which case it closes it
+ * (so `|x|` becomes `\left|x\right|`). Double bars (`||`) and any fence that does
+ * not find a match are left untouched as valid self-balanced delimiters.
  */
 export class FenceNormalizer {
   private readonly _root: MathMLElement;
@@ -67,14 +69,16 @@ class FencePairing {
     let paired = false;
 
     for (const child of this._children) {
-      if (this._isOpener(child)) {
+      const top = openFrames[openFrames.length - 1];
+
+      if (this._opensFrame(child, top)) {
         const frame: Frame = { opener: child, content: [] };
         openFrames.push(frame);
         current = frame.content;
         continue;
       }
 
-      if (this._isCloser(child) && openFrames.length > 0) {
+      if (this._closesFrame(child, top)) {
         const frame = openFrames.pop() as Frame;
         current = openFrames.length > 0 ? openFrames[openFrames.length - 1].content : root;
         current.push(this._makeFence(frame.opener, child, frame.content));
@@ -112,12 +116,34 @@ class FencePairing {
     return { name: 'mrow', value: '', children, attributes: {} };
   }
 
+  /** A directional opener, or a vertical bar when no bar is open at the current level. */
+  private _opensFrame(child: MathMLElement, top: Frame | undefined): boolean {
+    if (this._isOpener(child)) return true;
+    return this._isBar(child) && !this._isBarFrame(top);
+  }
+
+  /** A directional closer matching a directional frame, or a bar closing an open bar frame. */
+  private _closesFrame(child: MathMLElement, top: Frame | undefined): boolean {
+    if (top === undefined) return false;
+    if (this._isCloser(child) && this._isOpener(top.opener)) return true;
+    return this._isBar(child) && this._isBarFrame(top);
+  }
+
+  /** Whether the frame was opened by a vertical bar. */
+  private _isBarFrame(frame: Frame | undefined): boolean {
+    return frame !== undefined && this._isBar(frame.opener);
+  }
+
   private _isOpener(element: MathMLElement): boolean {
     return element.name === 'mo' && OPENERS.has(element.value.trim());
   }
 
   private _isCloser(element: MathMLElement): boolean {
     return element.name === 'mo' && CLOSERS.has(element.value.trim());
+  }
+
+  private _isBar(element: MathMLElement): boolean {
+    return element.name === 'mo' && element.value.trim() === '|';
   }
 }
 

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.ts
@@ -15,10 +15,11 @@ import { MathMLElement } from '../../protocols/mathml-element';
  * Pairing is positional (a closer matches the nearest open fence) and may mix
  * types (`(` with `]`), which `<mfenced>` renders as valid asymmetric
  * delimiters. Parentheses, square brackets and braces are directional. Vertical
- * bars (`|`) share one glyph for both sides, so they toggle: a bar opens a pair
- * unless one is already open at the current level, in which case it closes it
- * (so `|x|` becomes `\left|x\right|`). Double bars (`||`) and any fence that does
- * not find a match are left untouched as valid self-balanced delimiters.
+ * bars (`|`) and double bars (`||`) share one glyph for both sides, so they
+ * toggle: a bar opens a pair unless a same-glyph bar is already open at the
+ * current level, in which case it closes it (so `|x|` becomes `\left|x\right|`
+ * and `||x||` becomes the norm `\left\|x\right\|`). Any fence that does not find
+ * a match is left untouched as a valid self-balanced delimiter.
  */
 export class FenceNormalizer {
   private readonly _root: MathMLElement;
@@ -116,22 +117,23 @@ class FencePairing {
     return { name: 'mrow', value: '', children, attributes: {} };
   }
 
-  /** A directional opener, or a vertical bar when no bar is open at the current level. */
+  /** A directional opener, or a vertical bar that does not close the current frame. */
   private _opensFrame(child: MathMLElement, top: Frame | undefined): boolean {
     if (this._isOpener(child)) return true;
-    return this._isBar(child) && !this._isBarFrame(top);
+    return this._isBar(child) && !this._closesBar(child, top);
   }
 
-  /** A directional closer matching a directional frame, or a bar closing an open bar frame. */
+  /** A directional closer matching a directional frame, or a bar closing a same-glyph bar frame. */
   private _closesFrame(child: MathMLElement, top: Frame | undefined): boolean {
     if (top === undefined) return false;
     if (this._isCloser(child) && this._isOpener(top.opener)) return true;
-    return this._isBar(child) && this._isBarFrame(top);
+    return this._closesBar(child, top);
   }
 
-  /** Whether the frame was opened by a vertical bar. */
-  private _isBarFrame(frame: Frame | undefined): boolean {
-    return frame !== undefined && this._isBar(frame.opener);
+  /** Whether `child` is a bar that closes `top`, i.e. `top` is a bar frame opened by the same glyph. */
+  private _closesBar(child: MathMLElement, top: Frame | undefined): boolean {
+    if (top === undefined || !this._isBar(child) || !this._isBar(top.opener)) return false;
+    return top.opener.value.trim() === child.value.trim();
   }
 
   private _isOpener(element: MathMLElement): boolean {
@@ -143,12 +145,13 @@ class FencePairing {
   }
 
   private _isBar(element: MathMLElement): boolean {
-    return element.name === 'mo' && element.value.trim() === '|';
+    return element.name === 'mo' && BARS.has(element.value.trim());
   }
 }
 
 const OPENERS = new Set(['(', '[', '{']);
 const CLOSERS = new Set([')', ']', '}']);
+const BARS = new Set(['|', '||']);
 
 /** An open fence and the sibling content collected since, awaiting a closer. */
 interface Frame {

--- a/src/syntax/all-math-operators-by-char.ts
+++ b/src/syntax/all-math-operators-by-char.ts
@@ -426,7 +426,7 @@ export const allMathOperatorsByChar: Record<string, string> = {
   '&#x2191;': '\\uparrow',
   '&#x2190;': '\\leftarrow',
   '|||': '\\left|||\\right.',
-  '||': '\\left||\\right.',
+  '||': '\\left\\|\\right.',
   '|': '\\left|\\right.',
   '&#x2AFE;': '',
   '&#x2AFD;': '//',

--- a/src/syntax/all-math-operators-by-glyph.ts
+++ b/src/syntax/all-math-operators-by-glyph.ts
@@ -423,7 +423,7 @@ export const allMathOperatorsByGlyph: Record<string, string> = {
   '↑': '\\uparrow',
   '←': '\\leftarrow',
   '|||': '\\left|||\\right.',
-  '||': '\\left||\\right.',
+  '||': '\\left\\|\\right.',
   '|': '\\mid',
   '⫾': '',
   '⫽': '//',


### PR DESCRIPTION
## Summary

Follow-up to #68. Standalone `<mo>|</mo>` fence operators were converted in isolation, leaving dangling `\left|\right.` fillers. This pairs them into `<mfenced>` so `|x|` renders as a single stretchy `\left|x\right|`.

## Changes

- A vertical bar is treated as a toggled fence (same glyph opens or closes depending on whether a bar is already open at the current level).
- `|table|` becomes a `vmatrix` (determinant).
- Directional and bar closers are type-aware, so mixed nesting like `( |x| )` pairs correctly.
- Double bars (`||`) and lone/odd bars are left as valid self-balanced delimiters; the rare even-count separator-bar mispair (`x | y | z`) is pinned by a test as a known limitation.

All new outputs verified to parse in KaTeX.