### PR TITLE
feat(eval): add visual playground comparing MathML and converted LaTeX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 coverage
 *.tgz
+eval/report/

--- a/eval/README.md
+++ b/eval/README.md
@@ -1,0 +1,32 @@
+# mathml-to-latex eval
+
+Visual playground for inspecting conversions side by side. It imports the library straight from `../src`, so whatever branch or uncommitted change is in the working tree is what gets evaluated.
+
+This package is internal tooling: it is not published to npm (the root package ships `dist/` only) and its dependencies stay isolated from the library's.
+
+## Run
+
+```bash
+cd eval
+npm install
+npm run dev
+```
+
+Then open the printed URL (default `http://localhost:5173`).
+
+## Modes
+
+- **MathML → LaTeX** (default): paste MathML on the left; the converted LaTeX, its KaTeX validity verdict and both renderings appear live. Both sides render with the same MathJax engine (mml input vs tex input), so a visual difference means a conversion difference, not a renderer difference.
+- **Free LaTeX**: paste arbitrary LaTeX and see it rendered, to check a rendering hypothesis without going through the converter.
+
+The KaTeX verdict matters because MathJax is forgiving: KaTeX's strict parser is what flags output that would not compile in real LaTeX (double subscripts, unbalanced `\left`/`\right`, etc.).
+
+## Permalinks
+
+The current mode and input are encoded in the URL hash. Copy the URL to share an exact reproduction in an issue or PR.
+
+## Planned increments
+
+- `/gallery`: every fixture of the regression corpus rendered on a single page.
+- Fixture corpus + a browser-free jest test (convert each fixture, assert KaTeX accepts the result).
+- Optional batch mode (Playwright screenshots + visual diff ranking) if automated visual regression in CI becomes worth the cost; the gallery page is the surface it would capture.

--- a/eval/index.html
+++ b/eval/index.html
@@ -1,0 +1,56 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>mathml-to-latex playground</title>
+  </head>
+  <body>
+    <div id="app">
+      <header>
+        <h1>mathml-to-latex <span class="subtitle">playground</span></h1>
+        <nav id="mode-toggle" role="tablist">
+          <button type="button" data-mode="convert" class="active">MathML &rarr; LaTeX</button>
+          <button type="button" data-mode="free">Free LaTeX</button>
+        </nav>
+      </header>
+
+      <main id="convert-mode" class="two-panes">
+        <section class="pane">
+          <h2>MathML source</h2>
+          <textarea id="mathml-input" spellcheck="false" rows="12"></textarea>
+          <p id="convert-error" class="message error hidden"></p>
+          <h2>MathML rendered <span class="engine">MathJax (mml)</span></h2>
+          <div id="mathml-render" class="render"></div>
+          <p id="mathml-render-error" class="message error hidden"></p>
+        </section>
+
+        <section class="pane">
+          <h2>LaTeX output <button type="button" id="copy-latex" class="small">copy</button></h2>
+          <pre id="latex-output" class="code-output"></pre>
+          <p id="katex-status" class="message"></p>
+          <h2>LaTeX rendered <span class="engine">MathJax (tex)</span></h2>
+          <div id="latex-render" class="render"></div>
+        </section>
+      </main>
+
+      <main id="free-mode" class="hidden">
+        <section class="pane">
+          <h2>LaTeX source</h2>
+          <textarea id="free-input" spellcheck="false" rows="8"></textarea>
+          <p id="free-katex-status" class="message"></p>
+          <h2>Rendered <span class="engine">MathJax (tex)</span></h2>
+          <div id="free-render" class="render"></div>
+        </section>
+      </main>
+
+      <footer>
+        <p>
+          Converts with the library source at <code>../src</code> (current working tree). The URL hash keeps the
+          current input, so it can be shared as a permalink in issues and PRs.
+        </p>
+      </footer>
+    </div>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/eval/index.html
+++ b/eval/index.html
@@ -5,46 +5,53 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>mathml-to-latex playground</title>
   </head>
-  <body>
-    <div id="app">
-      <header>
-        <h1>mathml-to-latex <span class="subtitle">playground</span></h1>
-        <nav id="mode-toggle" role="tablist">
-          <button type="button" data-mode="convert" class="active">MathML &rarr; LaTeX</button>
-          <button type="button" data-mode="free">Free LaTeX</button>
+  <body class="bg-zinc-50 text-zinc-900">
+    <div id="app" class="mx-auto max-w-6xl p-6">
+      <header class="mb-5 flex items-center justify-between">
+        <h1 class="text-xl font-semibold">mathml-to-latex <span class="font-normal text-zinc-500">playground</span></h1>
+        <nav id="mode-toggle" role="tablist" class="inline-flex overflow-hidden rounded-lg border border-zinc-300 bg-white">
+          <button type="button" data-mode="convert" class="active cursor-pointer px-4 py-2 text-sm text-zinc-500">
+            MathML &rarr; LaTeX
+          </button>
+          <button type="button" data-mode="free" class="cursor-pointer px-4 py-2 text-sm text-zinc-500">Free LaTeX</button>
         </nav>
       </header>
 
-      <main id="convert-mode" class="two-panes">
-        <section class="pane">
-          <h2>MathML source</h2>
-          <textarea id="mathml-input" spellcheck="false" rows="12"></textarea>
-          <p id="convert-error" class="message error hidden"></p>
-          <h2>MathML rendered <span class="engine">MathJax (mml)</span></h2>
-          <div id="mathml-render" class="render"></div>
-          <p id="mathml-render-error" class="message error hidden"></p>
+      <main id="convert-mode" class="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <section class="rounded-xl border border-zinc-200 bg-white p-4">
+          <h2 class="pane-title">MathML source</h2>
+          <textarea id="mathml-input" spellcheck="false" rows="12" class="code-input"></textarea>
+          <p id="convert-error" class="message hidden"></p>
+          <h2 class="pane-title">MathML rendered <span class="normal-case font-normal">MathJax (mml)</span></h2>
+          <div id="mathml-render" class="render-box"></div>
+          <p id="mathml-render-error" class="message hidden"></p>
         </section>
 
-        <section class="pane">
-          <h2>LaTeX output <button type="button" id="copy-latex" class="small">copy</button></h2>
-          <pre id="latex-output" class="code-output"></pre>
+        <section class="rounded-xl border border-zinc-200 bg-white p-4">
+          <h2 class="pane-title">
+            LaTeX output
+            <button type="button" id="copy-latex" class="cursor-pointer rounded-md border border-zinc-300 bg-white px-2 py-0.5 text-[11px] normal-case tracking-normal text-zinc-500 hover:text-zinc-900">
+              copy
+            </button>
+          </h2>
+          <pre id="latex-output" class="code-input m-0 min-h-12 break-all whitespace-pre-wrap"></pre>
           <p id="katex-status" class="message"></p>
-          <h2>LaTeX rendered <span class="engine">MathJax (tex)</span></h2>
-          <div id="latex-render" class="render"></div>
+          <h2 class="pane-title">LaTeX rendered <span class="normal-case font-normal">MathJax (tex)</span></h2>
+          <div id="latex-render" class="render-box"></div>
         </section>
       </main>
 
       <main id="free-mode" class="hidden">
-        <section class="pane">
-          <h2>LaTeX source</h2>
-          <textarea id="free-input" spellcheck="false" rows="8"></textarea>
+        <section class="rounded-xl border border-zinc-200 bg-white p-4">
+          <h2 class="pane-title">LaTeX source</h2>
+          <textarea id="free-input" spellcheck="false" rows="8" class="code-input"></textarea>
           <p id="free-katex-status" class="message"></p>
-          <h2>Rendered <span class="engine">MathJax (tex)</span></h2>
-          <div id="free-render" class="render"></div>
+          <h2 class="pane-title">Rendered <span class="normal-case font-normal">MathJax (tex)</span></h2>
+          <div id="free-render" class="render-box"></div>
         </section>
       </main>
 
-      <footer>
+      <footer class="mt-5 text-xs text-zinc-500">
         <p>
           Converts with the library source at <code>../src</code> (current working tree). The URL hash keeps the
           current input, so it can be shared as a permalink in issues and PRs.

--- a/eval/index.html
+++ b/eval/index.html
@@ -10,10 +10,10 @@
       <header class="mb-5 flex items-center justify-between">
         <h1 class="text-xl font-semibold">mathml-to-latex <span class="font-normal text-zinc-500">playground</span></h1>
         <nav id="mode-toggle" role="tablist" class="inline-flex overflow-hidden rounded-lg border border-zinc-300 bg-white">
-          <button type="button" data-mode="convert" class="active cursor-pointer px-4 py-2 text-sm text-zinc-500">
+          <button type="button" data-mode="convert" class="active cursor-pointer px-4 py-2 text-sm">
             MathML &rarr; LaTeX
           </button>
-          <button type="button" data-mode="free" class="cursor-pointer px-4 py-2 text-sm text-zinc-500">Free LaTeX</button>
+          <button type="button" data-mode="free" class="cursor-pointer px-4 py-2 text-sm">Free LaTeX</button>
         </nav>
       </header>
 

--- a/eval/index.html
+++ b/eval/index.html
@@ -22,9 +22,6 @@
           <h2 class="pane-title">MathML source</h2>
           <textarea id="mathml-input" spellcheck="false" rows="12" class="code-input"></textarea>
           <p id="convert-error" class="message hidden"></p>
-          <h2 class="pane-title">MathML rendered <span class="normal-case font-normal">MathJax (mml)</span></h2>
-          <div id="mathml-render" class="render-box"></div>
-          <p id="mathml-render-error" class="message hidden"></p>
         </section>
 
         <section class="rounded-xl border border-zinc-200 bg-white p-4">
@@ -36,6 +33,15 @@
           </h2>
           <pre id="latex-output" class="code-input m-0 min-h-12 break-all whitespace-pre-wrap"></pre>
           <p id="katex-status" class="message"></p>
+        </section>
+
+        <section class="rounded-xl border border-zinc-200 bg-white p-4">
+          <h2 class="pane-title">MathML rendered <span class="normal-case font-normal">MathJax (mml)</span></h2>
+          <div id="mathml-render" class="render-box"></div>
+          <p id="mathml-render-error" class="message hidden"></p>
+        </section>
+
+        <section class="rounded-xl border border-zinc-200 bg-white p-4">
           <h2 class="pane-title">LaTeX rendered <span class="normal-case font-normal">MathJax (tex)</span></h2>
           <div id="latex-render" class="render-box"></div>
         </section>

--- a/eval/package-lock.json
+++ b/eval/package-lock.json
@@ -8,8 +8,10 @@
       "name": "mathml-to-latex-eval",
       "version": "0.1.0",
       "devDependencies": {
+        "@tailwindcss/vite": "^4.3.0",
         "katex": "^0.17.0",
         "mathjax": "^4.1.2",
+        "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
         "vite": "^8.0.16"
       }
@@ -46,6 +48,56 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@mathjax/mathjax-newcm-font": {
@@ -366,6 +418,290 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.3.0.tgz",
+      "integrity": "sha512-t6J3OrB5Fc0ExuhohouH0fWUGMYL6PTLhW+E7zIk/pdbnJARZDCwjBznFnkh5ynRnIRSI4YjtTH0t6USjJISrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "tailwindcss": "4.3.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.2",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
@@ -395,6 +731,20 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.23.0.tgz",
+      "integrity": "sha512-yJN/BOOLxcOW2aQgeif9mSnaUB8KtvmMMp56oA1kx1CRfBKbhZm2pJ+NBY+3eOboHxix8lfjWpHE0Ei5U8RbSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/fdir": {
@@ -428,6 +778,23 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/katex": {
@@ -720,6 +1087,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/mathjax": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.2.tgz",
@@ -840,6 +1217,27 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tinyglobby": {

--- a/eval/package-lock.json
+++ b/eval/package-lock.json
@@ -1,0 +1,963 @@
+{
+  "name": "mathml-to-latex-eval",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "mathml-to-latex-eval",
+      "version": "0.1.0",
+      "devDependencies": {
+        "katex": "^0.17.0",
+        "mathjax": "^4.1.2",
+        "typescript": "^6.0.3",
+        "vite": "^8.0.16"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@mathjax/mathjax-newcm-font": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.2.tgz",
+      "integrity": "sha512-lZHMjNP2XbABHA3kVn40rbse5ERUeMEmrGH03qLkCwxq4/5Z/eNLr0akw1MmQcqTwCbvkx1BFcmJ7RCfbRlw3Q==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@oxc-project/types": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.17.0.tgz",
+      "integrity": "sha512-Vdw0ATsQ9V+LuegM/BTwQqV/6cTl5lbGcIrU+BCgLxyf6bo38ybOr372tuSIxir3CN720flu1meYR6XzNMwQnw==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/mathjax": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.2.tgz",
+      "integrity": "sha512-EQDS8xBpVg179BXoLeZ9JlwUFftOC5qylw20UlAMDhrTuooENigOocY79aNkkFSyvj/AST/89ZAo12+r5bPI4w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mathjax/mathjax-newcm-font": "^4.1.2"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/eval/package.json
+++ b/eval/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mathml-to-latex-eval",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "description": "Visual playground and evaluator for mathml-to-latex. Not published; see README.md.",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "katex": "^0.17.0",
+    "mathjax": "^4.1.2",
+    "typescript": "^6.0.3",
+    "vite": "^8.0.16"
+  }
+}

--- a/eval/package.json
+++ b/eval/package.json
@@ -11,8 +11,10 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
+    "@tailwindcss/vite": "^4.3.0",
     "katex": "^0.17.0",
     "mathjax": "^4.1.2",
+    "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16"
   }

--- a/eval/src/converter.ts
+++ b/eval/src/converter.ts
@@ -1,0 +1,21 @@
+import { MathMLToLaTeX } from 'mathml-to-latex';
+
+export interface ConversionResult {
+  latex: string;
+  error: string | null;
+}
+
+/**
+ * Wraps the library under test (imported straight from `../src`, i.e. the
+ * current working tree) and turns converter exceptions into data the UI can
+ * display instead of letting them break the render loop.
+ */
+export class Converter {
+  convert(mathml: string): ConversionResult {
+    try {
+      return { latex: MathMLToLaTeX.convert(mathml), error: null };
+    } catch (error) {
+      return { latex: '', error: (error as Error).message };
+    }
+  }
+}

--- a/eval/src/env.d.ts
+++ b/eval/src/env.d.ts
@@ -1,0 +1,11 @@
+declare module 'mathjax/tex-mml-svg.js';
+
+// KaTeX ships no type declarations; only the call the validator uses is typed.
+declare module 'katex' {
+  interface KatexRenderOptions {
+    displayMode?: boolean;
+    throwOnError?: boolean;
+  }
+  const katex: { renderToString(tex: string, options?: KatexRenderOptions): string };
+  export default katex;
+}

--- a/eval/src/latex-validator.ts
+++ b/eval/src/latex-validator.ts
@@ -1,0 +1,19 @@
+import katex from 'katex';
+
+/**
+ * Strict LaTeX validity oracle. MathJax is forgiving by design, so the
+ * playground also runs every LaTeX string through KaTeX, whose parser rejects
+ * output that would not compile (e.g. double subscripts, unbalanced
+ * `\left`/`\right`), and surfaces the parse error message.
+ */
+export class LatexValidator {
+  /** @returns null when KaTeX accepts the string, otherwise the parse error message. */
+  validate(tex: string): string | null {
+    try {
+      katex.renderToString(tex, { displayMode: true, throwOnError: true });
+      return null;
+    } catch (error) {
+      return (error as Error).message;
+    }
+  }
+}

--- a/eval/src/main.ts
+++ b/eval/src/main.ts
@@ -1,0 +1,4 @@
+import './style.css';
+import { Playground } from './playground';
+
+new Playground().start();

--- a/eval/src/math-renderer.ts
+++ b/eval/src/math-renderer.ts
@@ -1,0 +1,65 @@
+declare global {
+  interface Window {
+    // Holds the config object before the bundle loads and the MathJax runtime after.
+    MathJax: unknown;
+  }
+}
+
+/** The slice of the MathJax runtime API the renderer relies on. */
+interface MathJaxRuntime {
+  tex2svg(tex: string, options: { display: boolean }): HTMLElement;
+  mathml2svg(mathml: string, options: { display: boolean }): HTMLElement;
+  startup: { promise: Promise<void>; document: { clear(): void; updateDocument(): void } };
+}
+
+/**
+ * Thin wrapper around MathJax used for both panes of the comparison: the
+ * MathML side (`mml` input) and the LaTeX side (`tex` input). Using the same
+ * engine on both sides keeps the comparison fair: a visual difference means a
+ * conversion difference, not a renderer difference.
+ *
+ * The SVG output is used instead of CHTML so no webfont loading is involved,
+ * which keeps rendering deterministic (and screenshot-friendly later).
+ */
+export class MathRenderer {
+  private readonly _ready: Promise<void>;
+
+  constructor() {
+    window.MathJax = {
+      startup: { typeset: false },
+      // Menu and assistive features are off: the a11y speech worker does not
+      // resolve under Vite's bundling and adds nothing to a comparison tool.
+      options: {
+        enableMenu: false,
+        enableEnrichment: false,
+        enableSpeech: false,
+        enableBraille: false,
+        a11y: { speech: false, braille: false },
+        menuOptions: { settings: { speech: false, braille: false, enrich: false } },
+      },
+    };
+    this._ready = import('mathjax/tex-mml-svg.js').then(() => this._mathjax.startup.promise);
+  }
+
+  /** Renders a LaTeX string into the target element. Throws on parse failure. */
+  async renderTeX(tex: string, target: HTMLElement): Promise<void> {
+    await this._ready;
+    this._replace(target, this._mathjax.tex2svg(tex, { display: true }));
+  }
+
+  /** Renders a MathML string into the target element. Throws on parse failure. */
+  async renderMathML(mathml: string, target: HTMLElement): Promise<void> {
+    await this._ready;
+    this._replace(target, this._mathjax.mathml2svg(mathml, { display: true }));
+  }
+
+  private _replace(target: HTMLElement, rendered: HTMLElement): void {
+    target.replaceChildren(rendered);
+    this._mathjax.startup.document.clear();
+    this._mathjax.startup.document.updateDocument();
+  }
+
+  private get _mathjax(): MathJaxRuntime {
+    return window.MathJax as MathJaxRuntime;
+  }
+}

--- a/eval/src/permalink.ts
+++ b/eval/src/permalink.ts
@@ -1,0 +1,34 @@
+export type PlaygroundMode = 'convert' | 'free';
+
+export interface PlaygroundState {
+  mode: PlaygroundMode;
+  input: string;
+}
+
+/**
+ * Persists the playground state in the URL hash, so any input can be shared
+ * as a permalink (e.g. a reproduction attached to an issue or PR).
+ */
+export class Permalink {
+  /** @returns the state encoded in the current URL hash, or null when absent/corrupt. */
+  read(): PlaygroundState | null {
+    const hash = window.location.hash.replace(/^#/, '');
+    if (!hash) return null;
+
+    try {
+      const decoded = JSON.parse(decodeURIComponent(escape(atob(hash))));
+      if ((decoded.mode === 'convert' || decoded.mode === 'free') && typeof decoded.input === 'string') {
+        return decoded as PlaygroundState;
+      }
+      return null;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Replaces the URL hash with the given state, without touching history. */
+  write(state: PlaygroundState): void {
+    const encoded = btoa(unescape(encodeURIComponent(JSON.stringify(state))));
+    window.history.replaceState(null, '', `#${encoded}`);
+  }
+}

--- a/eval/src/playground.ts
+++ b/eval/src/playground.ts
@@ -1,0 +1,162 @@
+import { Converter } from './converter';
+import { LatexValidator } from './latex-validator';
+import { MathRenderer } from './math-renderer';
+import { Permalink, PlaygroundMode } from './permalink';
+
+const DEFAULT_MATHML = `<math display="block">
+  <mtable displaystyle="true" columnalign="right left">
+    <mtr>
+      <mtd><msub><mi>a</mi><mn>1</mn></msub></mtd>
+      <mtd><mo>=</mo><msub><mi>b</mi><mn>1</mn></msub><mo>+</mo><msub><mi>c</mi><mn>1</mn></msub></mtd>
+    </mtr>
+    <mtr>
+      <mtd><msub><mi>a</mi><mn>2</mn></msub></mtd>
+      <mtd><mo>=</mo><msub><mi>b</mi><mn>2</mn></msub><mo>+</mo><msub><mi>c</mi><mn>2</mn></msub></mtd>
+    </mtr>
+  </mtable>
+</math>`;
+
+const DEFAULT_LATEX =
+  '{}_{92}^{238}\\mathrm{U} \\quad \\frac{1}{2} \\quad \\begin{aligned}a &= b \\\\ c &= d\\end{aligned}';
+
+const DEBOUNCE_MS = 300;
+
+/**
+ * Wires the two playground modes:
+ *
+ * - `convert`: MathML in, library LaTeX out, both rendered side by side with
+ *   the same MathJax engine, plus the KaTeX validity verdict on the output;
+ * - `free`: arbitrary LaTeX in, rendered directly, for checking a rendering
+ *   hypothesis without going through the converter.
+ *
+ * Inputs are persisted in the URL hash as a shareable permalink.
+ */
+export class Playground {
+  private readonly _converter = new Converter();
+  private readonly _validator = new LatexValidator();
+  private readonly _renderer = new MathRenderer();
+  private readonly _permalink = new Permalink();
+
+  private _mode: PlaygroundMode = 'convert';
+  private _debounceTimer: number | undefined;
+
+  start(): void {
+    const initial = this._permalink.read();
+    this._mathmlInput().value = initial?.mode === 'convert' ? initial.input : DEFAULT_MATHML;
+    this._freeInput().value = initial?.mode === 'free' ? initial.input : DEFAULT_LATEX;
+
+    this._wireModeToggle();
+    this._wireInputs();
+    this._wireCopyButton();
+
+    this._switchMode(initial?.mode ?? 'convert');
+  }
+
+  private _wireModeToggle(): void {
+    for (const button of document.querySelectorAll<HTMLButtonElement>('#mode-toggle button')) {
+      button.addEventListener('click', () => this._switchMode(button.dataset.mode as PlaygroundMode));
+    }
+  }
+
+  private _wireInputs(): void {
+    this._mathmlInput().addEventListener('input', () => this._scheduleUpdate());
+    this._freeInput().addEventListener('input', () => this._scheduleUpdate());
+  }
+
+  private _wireCopyButton(): void {
+    const button = document.querySelector<HTMLButtonElement>('#copy-latex')!;
+    button.addEventListener('click', () => {
+      void navigator.clipboard.writeText(this._latexOutput().textContent ?? '');
+      button.textContent = 'copied!';
+      window.setTimeout(() => (button.textContent = 'copy'), 1200);
+    });
+  }
+
+  private _switchMode(mode: PlaygroundMode): void {
+    this._mode = mode;
+    for (const button of document.querySelectorAll<HTMLButtonElement>('#mode-toggle button')) {
+      button.classList.toggle('active', button.dataset.mode === mode);
+    }
+    document.getElementById('convert-mode')!.classList.toggle('hidden', mode !== 'convert');
+    document.getElementById('free-mode')!.classList.toggle('hidden', mode !== 'free');
+    void this._update();
+  }
+
+  private _scheduleUpdate(): void {
+    window.clearTimeout(this._debounceTimer);
+    this._debounceTimer = window.setTimeout(() => void this._update(), DEBOUNCE_MS);
+  }
+
+  private async _update(): Promise<void> {
+    const input = this._mode === 'convert' ? this._mathmlInput().value : this._freeInput().value;
+    this._permalink.write({ mode: this._mode, input });
+
+    if (this._mode === 'convert') await this._updateConvertMode(input);
+    else await this._updateFreeMode(input);
+  }
+
+  private async _updateConvertMode(mathml: string): Promise<void> {
+    const { latex, error } = this._converter.convert(mathml);
+
+    this._setMessage('convert-error', error, 'error');
+    this._latexOutput().textContent = latex;
+    this._setValidity('katex-status', latex);
+
+    await this._renderInto('mathml-render', 'mathml-render-error', () =>
+      this._renderer.renderMathML(mathml, document.getElementById('mathml-render')!),
+    );
+    await this._renderInto('latex-render', null, () =>
+      this._renderer.renderTeX(latex, document.getElementById('latex-render')!),
+    );
+  }
+
+  private async _updateFreeMode(latex: string): Promise<void> {
+    this._setValidity('free-katex-status', latex);
+    await this._renderInto('free-render', null, () =>
+      this._renderer.renderTeX(latex, document.getElementById('free-render')!),
+    );
+  }
+
+  private async _renderInto(targetId: string, errorId: string | null, render: () => Promise<void>): Promise<void> {
+    try {
+      await render();
+      if (errorId) this._setMessage(errorId, null, 'error');
+    } catch (error) {
+      document.getElementById(targetId)!.replaceChildren();
+      if (errorId) this._setMessage(errorId, (error as Error).message, 'error');
+    }
+  }
+
+  private _setValidity(elementId: string, latex: string): void {
+    const element = document.getElementById(elementId)!;
+    const verdict = latex ? this._validator.validate(latex) : null;
+
+    element.classList.remove('valid', 'invalid');
+    if (!latex) {
+      element.textContent = '';
+      return;
+    }
+
+    element.classList.add(verdict === null ? 'valid' : 'invalid');
+    element.textContent = verdict === null ? 'KaTeX: valid LaTeX' : `KaTeX: ${verdict}`;
+  }
+
+  private _setMessage(elementId: string, message: string | null, kind: 'error'): void {
+    const element = document.getElementById(elementId)!;
+    element.classList.toggle('hidden', message === null);
+    element.classList.add(kind);
+    element.textContent = message ?? '';
+  }
+
+  private _mathmlInput(): HTMLTextAreaElement {
+    return document.getElementById('mathml-input') as HTMLTextAreaElement;
+  }
+
+  private _freeInput(): HTMLTextAreaElement {
+    return document.getElementById('free-input') as HTMLTextAreaElement;
+  }
+
+  private _latexOutput(): HTMLPreElement {
+    return document.getElementById('latex-output') as HTMLPreElement;
+  }
+}

--- a/eval/src/style.css
+++ b/eval/src/style.css
@@ -33,6 +33,12 @@
     @apply text-green-700;
   }
 
+  /* Text color must live in this layer: an inline `text-*` utility would sit
+     in the later utilities layer and override the `.active` state. */
+  #mode-toggle button {
+    @apply text-zinc-500;
+  }
+
   #mode-toggle button.active {
     @apply bg-blue-600 text-white;
   }

--- a/eval/src/style.css
+++ b/eval/src/style.css
@@ -1,183 +1,39 @@
-:root {
-  --bg: #f7f7f8;
-  --pane: #ffffff;
-  --border: #d9d9e0;
-  --text: #1d1d20;
-  --muted: #71717a;
-  --accent: #2563eb;
-  --error-bg: #fef2f2;
-  --error-text: #b91c1c;
-  --ok-text: #15803d;
-  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
-}
+@import 'tailwindcss';
 
-* {
-  box-sizing: border-box;
-}
+/* One-off layout/styling lives as utility classes in index.html. This layer
+   covers the patterns repeated across panes and the state classes toggled at
+   runtime by playground.ts. */
+@layer components {
+  .pane-title {
+    @apply mt-4 mb-2 flex items-center gap-2 text-xs font-semibold tracking-wide text-zinc-500 uppercase first:mt-0;
+  }
 
-body {
-  margin: 0;
-  background: var(--bg);
-  color: var(--text);
-}
+  .code-input {
+    @apply w-full rounded-lg border border-zinc-300 bg-zinc-50 p-2.5 font-mono text-sm leading-6;
+  }
 
-#app {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1.5rem;
-}
+  textarea.code-input {
+    @apply resize-y;
+  }
 
-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 1.25rem;
-}
+  .render-box {
+    @apply flex min-h-20 items-center justify-center overflow-x-auto rounded-lg border border-dashed border-zinc-300 p-3;
+  }
 
-h1 {
-  font-size: 1.25rem;
-  margin: 0;
-}
+  .message {
+    @apply mt-1.5 text-xs;
+  }
 
-h1 .subtitle {
-  color: var(--muted);
-  font-weight: 400;
-}
+  .message.error,
+  .message.invalid {
+    @apply rounded-md bg-red-50 px-2.5 py-1.5 text-red-700;
+  }
 
-#mode-toggle {
-  display: inline-flex;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  overflow: hidden;
-  background: var(--pane);
-}
+  .message.valid {
+    @apply text-green-700;
+  }
 
-#mode-toggle button {
-  border: 0;
-  background: transparent;
-  padding: 0.5rem 1rem;
-  font-size: 0.9rem;
-  cursor: pointer;
-  color: var(--muted);
-}
-
-#mode-toggle button.active {
-  background: var(--accent);
-  color: #fff;
-}
-
-.two-panes {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
-}
-
-.pane {
-  background: var(--pane);
-  border: 1px solid var(--border);
-  border-radius: 10px;
-  padding: 1rem;
-}
-
-h2 {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--muted);
-  margin: 1rem 0 0.5rem;
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-h2:first-child {
-  margin-top: 0;
-}
-
-h2 .engine {
-  font-weight: 400;
-  text-transform: none;
-  letter-spacing: 0;
-}
-
-textarea,
-.code-output {
-  width: 100%;
-  font-family: ui-monospace, 'Cascadia Code', Menlo, monospace;
-  font-size: 0.85rem;
-  line-height: 1.5;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  padding: 0.6rem;
-  background: #fbfbfc;
-  color: var(--text);
-}
-
-textarea {
-  resize: vertical;
-}
-
-.code-output {
-  min-height: 3rem;
-  margin: 0;
-  white-space: pre-wrap;
-  word-break: break-all;
-}
-
-.render {
-  min-height: 4.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 1px dashed var(--border);
-  border-radius: 8px;
-  padding: 0.75rem;
-  overflow-x: auto;
-}
-
-.message {
-  font-size: 0.8rem;
-  margin: 0.4rem 0 0;
-}
-
-.message.error,
-.message.invalid {
-  background: var(--error-bg);
-  color: var(--error-text);
-  border-radius: 6px;
-  padding: 0.4rem 0.6rem;
-}
-
-.message.valid {
-  color: var(--ok-text);
-}
-
-.hidden {
-  display: none;
-}
-
-button.small {
-  font-size: 0.7rem;
-  border: 1px solid var(--border);
-  background: var(--pane);
-  border-radius: 6px;
-  padding: 0.15rem 0.5rem;
-  cursor: pointer;
-  color: var(--muted);
-}
-
-button.small:hover {
-  color: var(--text);
-}
-
-footer {
-  margin-top: 1.25rem;
-  color: var(--muted);
-  font-size: 0.8rem;
-}
-
-@media (max-width: 900px) {
-  .two-panes {
-    grid-template-columns: 1fr;
+  #mode-toggle button.active {
+    @apply bg-blue-600 text-white;
   }
 }

--- a/eval/src/style.css
+++ b/eval/src/style.css
@@ -1,0 +1,183 @@
+:root {
+  --bg: #f7f7f8;
+  --pane: #ffffff;
+  --border: #d9d9e0;
+  --text: #1d1d20;
+  --muted: #71717a;
+  --accent: #2563eb;
+  --error-bg: #fef2f2;
+  --error-text: #b91c1c;
+  --ok-text: #15803d;
+  font-family: system-ui, -apple-system, 'Segoe UI', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+#app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+h1 .subtitle {
+  color: var(--muted);
+  font-weight: 400;
+}
+
+#mode-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--pane);
+}
+
+#mode-toggle button {
+  border: 0;
+  background: transparent;
+  padding: 0.5rem 1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+#mode-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.two-panes {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.pane {
+  background: var(--pane);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem;
+}
+
+h2 {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  margin: 1rem 0 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+h2:first-child {
+  margin-top: 0;
+}
+
+h2 .engine {
+  font-weight: 400;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+textarea,
+.code-output {
+  width: 100%;
+  font-family: ui-monospace, 'Cascadia Code', Menlo, monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0.6rem;
+  background: #fbfbfc;
+  color: var(--text);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.code-output {
+  min-height: 3rem;
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+.render {
+  min-height: 4.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 0.75rem;
+  overflow-x: auto;
+}
+
+.message {
+  font-size: 0.8rem;
+  margin: 0.4rem 0 0;
+}
+
+.message.error,
+.message.invalid {
+  background: var(--error-bg);
+  color: var(--error-text);
+  border-radius: 6px;
+  padding: 0.4rem 0.6rem;
+}
+
+.message.valid {
+  color: var(--ok-text);
+}
+
+.hidden {
+  display: none;
+}
+
+button.small {
+  font-size: 0.7rem;
+  border: 1px solid var(--border);
+  background: var(--pane);
+  border-radius: 6px;
+  padding: 0.15rem 0.5rem;
+  cursor: pointer;
+  color: var(--muted);
+}
+
+button.small:hover {
+  color: var(--text);
+}
+
+footer {
+  margin-top: 1.25rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+
+@media (max-width: 900px) {
+  .two-panes {
+    grid-template-columns: 1fr;
+  }
+}

--- a/eval/tsconfig.json
+++ b/eval/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["vite/client"],
+    "paths": {
+      "mathml-to-latex": ["../src/index.ts"],
+      "data/*": ["../src/data/*"],
+      "domain/*": ["../src/domain/*"]
+    }
+  },
+  "include": ["src", "vite.config.ts"]
+}

--- a/eval/vite.config.ts
+++ b/eval/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vite';
+import tailwindcss from '@tailwindcss/vite';
 import path from 'node:path';
 
 // The playground imports the library straight from `../src`, so it always
@@ -6,6 +7,7 @@ import path from 'node:path';
 // aliases mirror the `paths` of the root tsconfig, which the library source
 // relies on for its bare `data/...` and `domain/...` imports.
 export default defineConfig({
+  plugins: [tailwindcss()],
   resolve: {
     alias: {
       'mathml-to-latex': path.resolve(__dirname, '../src/index.ts'),

--- a/eval/vite.config.ts
+++ b/eval/vite.config.ts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import path from 'node:path';
+
+// The playground imports the library straight from `../src`, so it always
+// evaluates the current working tree (no intermediate `npm run build`). The
+// aliases mirror the `paths` of the root tsconfig, which the library source
+// relies on for its bare `data/...` and `domain/...` imports.
+export default defineConfig({
+  resolve: {
+    alias: {
+      'mathml-to-latex': path.resolve(__dirname, '../src/index.ts'),
+      data: path.resolve(__dirname, '../src/data'),
+      domain: path.resolve(__dirname, '../src/domain'),
+    },
+  },
+  server: {
+    fs: { allow: [path.resolve(__dirname, '..')] },
+  },
+});


### PR DESCRIPTION
## Summary

Adds `eval/`, an internal visual playground for inspecting conversions side by side. It imports the library straight from `../src`, so it always evaluates the current working tree — useful while fixing converters (e.g. the upcoming `mmultiscripts` work) and for sharing reproductions in issues.

## Features

- **MathML → LaTeX mode**: paste MathML; the converted LaTeX, a KaTeX validity verdict and both renderings appear live. Both sides render with the same MathJax engine (mml vs tex input), so a visual difference means a conversion difference, not a renderer difference.
- **Free LaTeX mode**: render arbitrary LaTeX directly, to check a rendering hypothesis without going through the converter.
- **Permalinks**: mode + input encoded in the URL hash, shareable in issues/PRs.
- Converter exceptions and KaTeX parse errors surface as panel messages (KaTeX is the strict oracle; MathJax is forgiving by design).

## Notes

- Self-contained package (`cd eval && npm install && npm run dev`); its dependencies stay out of the root `package.json` and nothing ships to npm (root `files` allowlist is `dist/` only).
- MathJax 4's a11y speech worker breaks under Vite bundling and is disabled in config (documented in `MathRenderer`).
- Planned increments (see `eval/README.md`): `/gallery` over a fixture corpus, a browser-free jest test asserting KaTeX accepts every fixture's output, and optional Playwright batch screenshots if automated visual regression becomes worth the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)