### PR TITLE
fix(fences): handle unicode double-bar norm delimiters (∥, ‖)

### DIFF
--- a/src/data/helpers/wrappers/generic.test.ts
+++ b/src/data/helpers/wrappers/generic.test.ts
@@ -16,4 +16,11 @@ describe('GenericWrapper', () => {
   it('maps a double bar to the norm delimiter', () => {
     expect(new GenericWrapper('||', '||').wrap('x')).toBe('\\left\\|x\\right\\|');
   });
+
+  it.each([
+    { name: 'parallel-to glyph (U+2225)', fence: '∥' },
+    { name: 'double vertical line glyph (U+2016)', fence: '‖' },
+  ])('maps the $name to the norm delimiter (issue #43)', ({ fence }) => {
+    expect(new GenericWrapper(fence, fence).wrap('x')).toBe('\\left\\|x\\right\\|');
+  });
 });

--- a/src/data/helpers/wrappers/generic.ts
+++ b/src/data/helpers/wrappers/generic.ts
@@ -26,11 +26,15 @@ export class GenericWrapper {
 
 /**
  * MathML fence characters that are not valid `\left`/`\right` delimiters as-is:
- * braces are grouping characters (need `\{`/`\}`) and a double bar is the norm
- * delimiter `\|` (a bare `\left||` is a stretchy bar followed by a literal one).
+ * braces are grouping characters (need `\{`/`\}`) and the double-bar forms are
+ * the norm delimiter `\|` (a bare `\left||` is a stretchy bar followed by a
+ * literal one, and the unicode glyphs `‖`/`∥` are not delimiters LaTeX
+ * knows at all, as in issue #43).
  */
 const DELIMITER_TRANSLATIONS = new Map([
   ['{', '\\{'],
   ['}', '\\}'],
   ['||', '\\|'],
+  ['‖', '\\|'],
+  ['∥', '\\|'],
 ]);

--- a/src/data/helpers/wrappers/generic.ts
+++ b/src/data/helpers/wrappers/generic.ts
@@ -1,4 +1,5 @@
 import { Wrapper } from './wrapper';
+import { doubleBarFenceGlyphs } from '../../../syntax';
 
 /**
  * Wraps a string with auto-sizing LaTeX delimiters, prefixing the given
@@ -26,15 +27,13 @@ export class GenericWrapper {
 
 /**
  * MathML fence characters that are not valid `\left`/`\right` delimiters as-is:
- * braces are grouping characters (need `\{`/`\}`) and the double-bar forms are
- * the norm delimiter `\|` (a bare `\left||` is a stretchy bar followed by a
- * literal one, and the unicode glyphs `‖`/`∥` are not delimiters LaTeX
- * knows at all, as in issue #43).
+ * braces are grouping characters (need `\{`/`\}`) and the double-bar family
+ * is the norm delimiter `\|` (a bare `\left||` is a stretchy bar followed by a
+ * literal one, and the unicode glyphs are not delimiters LaTeX knows at all,
+ * as in issue #43).
  */
 const DELIMITER_TRANSLATIONS = new Map([
   ['{', '\\{'],
   ['}', '\\}'],
-  ['||', '\\|'],
-  ['‖', '\\|'],
-  ['∥', '\\|'],
+  ...[...doubleBarFenceGlyphs].map((glyph): [string, string] => [glyph, '\\|']),
 ]);

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mfenced/separators.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mfenced/separators.ts
@@ -1,3 +1,4 @@
+import { doubleBarFenceGlyphs } from '../../../../../syntax';
 import { GenericWrapper } from '../../../../helpers';
 
 /** Classifies a pair of open/close fences and wraps content in them. */
@@ -28,8 +29,7 @@ export class Separators {
   }
 
   areParallels(): boolean {
-    // Ascii double bar and the unicode double-bar glyphs (issue #43).
-    return this._compare('||', '||') || this._compare('‖', '‖') || this._compare('∥', '∥');
+    return this.open === this.close && doubleBarFenceGlyphs.has(this.open);
   }
 
   areNotEqual(): boolean {

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mfenced/separators.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mfenced/separators.ts
@@ -28,7 +28,8 @@ export class Separators {
   }
 
   areParallels(): boolean {
-    return this._compare('||', '||');
+    // Ascii double bar and the unicode double-bar glyphs (issue #43).
+    return this._compare('||', '||') || this._compare('‖', '‖') || this._compare('∥', '∥');
   }
 
   areNotEqual(): boolean {

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.integration.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.integration.test.ts
@@ -105,8 +105,18 @@ describe('normalize-fences (integration)', () => {
       latex: 'a \\parallel b',
     },
     {
+      name: 'a lone double-vertical-line glyph keeps its standalone meaning',
+      mathml: '<math><mrow><mi>a</mi><mo>‖</mo><mi>b</mi></mrow></math>',
+      latex: 'a \\parallel b',
+    },
+    {
       name: 'a scripted norm closes through the script base (issue #43)',
       mathml: '<math><mo>∥</mo><mi>P</mi><msubsup><mrow><mo>∥</mo></mrow><mi>F</mi><mn>2</mn></msubsup></math>',
+      latex: '\\left\\|P\\right\\|_{F}^{2}',
+    },
+    {
+      name: 'a scripted norm with the double-vertical-line glyph closes through the script base',
+      mathml: '<math><mo>‖</mo><mi>P</mi><msubsup><mrow><mo>‖</mo></mrow><mi>F</mi><mn>2</mn></msubsup></math>',
       latex: '\\left\\|P\\right\\|_{F}^{2}',
     },
     {

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.integration.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.integration.test.ts
@@ -90,6 +90,58 @@ describe('normalize-fences (integration)', () => {
       latex: '\\left(a\\right) \\left\\|\\right. b',
     },
     {
+      name: 'a parallel-to glyph pair (norm, issue #43) renders with \\| delimiters',
+      mathml: '<math><mrow><mo>∥</mo><mi>P</mi><mo>∥</mo></mrow></math>',
+      latex: '\\left\\|P\\right\\|',
+    },
+    {
+      name: 'a double-vertical-line glyph pair renders with \\| delimiters',
+      mathml: '<math><mrow><mo>‖</mo><mi>P</mi><mo>‖</mo></mrow></math>',
+      latex: '\\left\\|P\\right\\|',
+    },
+    {
+      name: 'a lone parallel-to glyph keeps its relational meaning',
+      mathml: '<math><mrow><mi>a</mi><mo>∥</mo><mi>b</mi></mrow></math>',
+      latex: 'a \\parallel b',
+    },
+    {
+      name: 'a scripted norm closes through the script base (issue #43)',
+      mathml: '<math><mo>∥</mo><mi>P</mi><msubsup><mrow><mo>∥</mo></mrow><mi>F</mi><mn>2</mn></msubsup></math>',
+      latex: '\\left\\|P\\right\\|_{F}^{2}',
+    },
+    {
+      name: 'two scripted norms do not cross-pair',
+      mathml:
+        '<math><mo>∥</mo><mi>P</mi><msubsup><mrow><mo>∥</mo></mrow><mi>F</mi><mn>2</mn></msubsup><mo>+</mo><mo>∥</mo><mi>Q</mi><msubsup><mrow><mo>∥</mo></mrow><mi>F</mi><mn>2</mn></msubsup></math>',
+      latex: '\\left\\|P\\right\\|_{F}^{2} + \\left\\|Q\\right\\|_{F}^{2}',
+    },
+    {
+      name: 'an evaluated-at bar closes through the msub base',
+      mathml: '<math><mo>|</mo><mi>f</mi><msub><mrow><mo>|</mo></mrow><mi>a</mi></msub></math>',
+      latex: '\\left|f\\right|_{a}',
+    },
+    {
+      name: 'a scripted bar with no open frame stays untouched',
+      mathml: '<math><msubsup><mrow><mo>∥</mo></mrow><mi>F</mi><mn>2</mn></msubsup></math>',
+      latex: '\\parallel_{F}^{2}',
+    },
+    {
+      name: 'a parallel-to glyph pair around a table becomes a Vmatrix',
+      mathml: `
+<math>
+  <mrow>
+    <mo>∥</mo>
+    <mtable>
+      <mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr>
+      <mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr>
+    </mtable>
+    <mo>∥</mo>
+  </mrow>
+</math>
+`,
+      latex: '\\begin{Vmatrix} 1 & 2 \\\\ 3 & 4 \\end{Vmatrix}',
+    },
+    {
       // A single separator bar (divides, such-that, evaluated-at) never pairs,
       // so it stays exactly as it converts today.
       name: 'a lone separator bar stays untouched',

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.ts
@@ -88,6 +88,16 @@ class FencePairing {
         continue;
       }
 
+      const scriptCloser = this._scriptBaseCloser(child, top);
+      if (scriptCloser !== undefined) {
+        const frame = openFrames.pop() as Frame;
+        current = openFrames.length > 0 ? openFrames[openFrames.length - 1].content : root;
+        const fence = this._makeFence(frame.opener, scriptCloser, frame.content);
+        current.push({ ...child, children: [fence, ...child.children.slice(1)] });
+        paired = true;
+        continue;
+      }
+
       current.push(child);
     }
 
@@ -116,6 +126,28 @@ class FencePairing {
   /** Wraps several nodes in a single `<mrow>` so `<mfenced>` does not insert separators between them. */
   private _wrapInRow(children: MathMLElement[]): MathMLElement {
     return { name: 'mrow', value: '', children, attributes: {} };
+  }
+
+  /**
+   * Detects the closing bar of a scripted norm, the shape editors emit for
+   * `‖P‖_F^2`: a script element whose base holds only the bar that matches the
+   * open bar frame (`<mo>∥</mo><mi>P</mi><msubsup><mrow><mo>∥</mo></mrow>F 2`,
+   * issue #43). Without this, the nested closer is invisible to the sibling
+   * pass and the opener would pair with the *next* norm's opener, fencing the
+   * wrong span. The frame content becomes the fence and the script attaches to
+   * it: `msubsup(mfenced(P), F, 2)`.
+   *
+   * @returns the matching bar, or undefined when the child is not this shape.
+   */
+  private _scriptBaseCloser(child: MathMLElement, top: Frame | undefined): MathMLElement | undefined {
+    if (top === undefined || !this._isBar(top.opener)) return undefined;
+    if (!SCRIPT_ELEMENTS.has(child.name) || child.children.length === 0) return undefined;
+
+    const base = child.children[0];
+    const bar = base.name === 'mrow' && base.children.length === 1 ? base.children[0] : base;
+    if (bar.name !== 'mo' || bar.value.trim() !== top.opener.value.trim()) return undefined;
+
+    return bar;
   }
 
   /** A directional opener, or a vertical bar that does not close the current frame. */
@@ -152,7 +184,13 @@ class FencePairing {
 
 const OPENERS = new Set(['(', '[', '{']);
 const CLOSERS = new Set([')', ']', '}']);
-const BARS = new Set(['|', '||']);
+// The unicode double-bar glyphs (`‖` U+2016, `∥` U+2225) toggle like their
+// ascii counterparts: a sibling pair is read as a norm (issue #43). An odd
+// leftover spills back and keeps its relational meaning (`\parallel`).
+const BARS = new Set(['|', '||', '‖', '∥']);
+
+/** Script elements whose base can hide the closing bar of a norm. */
+const SCRIPT_ELEMENTS = new Set(['msub', 'msup', 'msubsup']);
 
 /** An open fence and the sibling content collected since, awaiting a closer. */
 interface Frame {

--- a/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/fence-normalizer.ts
@@ -1,5 +1,6 @@
 import { MathMLElement } from '../../protocols/mathml-element';
 import { TreeNormalizer } from './tree-normalizer';
+import { doubleBarFenceGlyphs } from '../../../syntax';
 
 /**
  * Normalizes bare fence operators into `<mfenced>` elements, in place.
@@ -184,10 +185,10 @@ class FencePairing {
 
 const OPENERS = new Set(['(', '[', '{']);
 const CLOSERS = new Set([')', ']', '}']);
-// The unicode double-bar glyphs (`‖` U+2016, `∥` U+2225) toggle like their
-// ascii counterparts: a sibling pair is read as a norm (issue #43). An odd
-// leftover spills back and keeps its relational meaning (`\parallel`).
-const BARS = new Set(['|', '||', '‖', '∥']);
+// Single bar plus the double-bar family: bars toggle, so a sibling pair is
+// read as an absolute value or norm (issue #43), while an odd leftover spills
+// back and keeps its standalone meaning (`\mid`, `\parallel`).
+const BARS = new Set(['|', ...doubleBarFenceGlyphs]);
 
 /** Script elements whose base can hide the closing bar of a norm. */
 const SCRIPT_ELEMENTS = new Set(['msub', 'msup', 'msubsup']);

--- a/src/latex-environment-invariant.test.ts
+++ b/src/latex-environment-invariant.test.ts
@@ -50,7 +50,7 @@ const pick = <T>(random: Random, options: T[]): T => options[Math.floor(random()
 
 const MI_VALUES = ['x', 'y', 'sin', 'α'];
 const MN_VALUES = ['1', '42', '3.14'];
-const MO_VALUES = ['+', '=', '−', '(', ')', '[', ']', '{', '}', '|', '∥', '≤', '→', '∑', ''];
+const MO_VALUES = ['+', '=', '−', '(', ')', '[', ']', '{', '}', '|', '∥', '‖', '≤', '→', '∑', ''];
 const MTEXT_VALUES = ['if', 'caf', 'a b'];
 const FENCE_PAIRS = [
   ['(', ')'],

--- a/src/latex-environment-invariant.test.ts
+++ b/src/latex-environment-invariant.test.ts
@@ -50,7 +50,7 @@ const pick = <T>(random: Random, options: T[]): T => options[Math.floor(random()
 
 const MI_VALUES = ['x', 'y', 'sin', 'α'];
 const MN_VALUES = ['1', '42', '3.14'];
-const MO_VALUES = ['+', '=', '−', '(', ')', '[', ']', '{', '}', '|', '≤', '→', '∑', ''];
+const MO_VALUES = ['+', '=', '−', '(', ')', '[', ']', '{', '}', '|', '∥', '≤', '→', '∑', ''];
 const MTEXT_VALUES = ['if', 'caf', 'a b'];
 const FENCE_PAIRS = [
   ['(', ')'],

--- a/src/syntax/fence-glyphs.ts
+++ b/src/syntax/fence-glyphs.ts
@@ -1,0 +1,9 @@
+/**
+ * The glyphs MathML uses for double-bar (norm) fences: the ascii digraph and
+ * the unicode characters `‖` (U+2016) and `∥` (U+2225), as in issue #43.
+ *
+ * Centralized so every consumer stays in sync: the fence normalizer (sibling
+ * pairing), the generic wrapper (translation to the `\|` delimiter) and the
+ * mfenced separators (Vmatrix classification).
+ */
+export const doubleBarFenceGlyphs: ReadonlySet<string> = new Set(['||', '‖', '∥']);

--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -2,6 +2,7 @@ export * from './all-math-operators-by-char';
 export * from './all-math-operators-by-glyph';
 export * from './all-math-symbols-by-char';
 export * from './all-math-symbols-by-glyph';
+export * from './fence-glyphs';
 export * from './latex-accents';
 export * from './math-numbers-by-glyph';
 export * from './utf8-converter';


### PR DESCRIPTION
## Summary

Addresses #43 (kept open on purpose: a reply to the reporter covering the trade-offs will follow before closing).

The unicode double-bar glyphs `∥` (U+2225) and `‖` (U+2016), which real-world MathML uses for norms, were not handled as fences anywhere in the pipeline. The reported equation produced the invalid `\left∥...\right∥` (KaTeX: `Invalid delimiter '∥' after '\left'`) and `\parallel`-spaced norms. The other half of the original report (the bare `mtable` emitting raw `\\`) was already fixed by #75.

## Changes

- `wrappers/generic.ts`: `∥`/`‖` translate to the norm delimiter `\|` in `\left`/`\right` position — this alone makes the issue's equation compile.
- `fence-normalizer.ts`: `∥`/`‖` join the bar set, so sibling pairs toggle into `\left\|...\right\|` like `|`/`||` already did; an odd leftover keeps its relational meaning (`a \parallel b`).
- `fence-normalizer.ts`: new script-base closer — the shape emitters produce for scripted norms (`<mo>∥</mo><mi>P</mi><msubsup><mrow><mo>∥</mo></mrow><mi>F</mi><mn>2</mn></msubsup>`) closes the open bar frame through the script's base, yielding `\left\|P\right\|_{F}^{2}` with the script attached to the fence. Without this, the nested closer is invisible to the sibling pass and consecutive norms would cross-pair around the wrong span (caught by running the issue's own equation). The ascii evaluated-at shape (`\left|f\right|_{a}`) benefits too.
- `mfenced/separators.ts`: `∥`/`‖` classify as parallels, so a fenced table becomes a `Vmatrix`.

The issue's full equation now converts to valid LaTeX with all three Frobenius norms as proper stretchy delimiters:

```latex
I = \frac{1}{2} \left\|R - \left(P Q\right)^{T}\right\|_{F}^{2} + \frac{\lambda_{P}}{2} \left\|P\right\|_{F}^{2} + \frac{\lambda_{Q}}{2} \left\|Q\right\|_{F}^{2} , ...
```

Verified with 14 directed cases (all KaTeX-validated), the `∥` glyph added to the property-based invariant test's vocabulary, and the full audit battery byte-for-byte unchanged except the intended `‖x‖` improvement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
