### PR TITLE
chore(release): bump version to 1.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mathml-to-latex",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mathml-to-latex",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.10"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mathml-to-latex",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "A JavaScript tool to convert mathml string to LaTeX string",
   "main": "dist/index.cjs",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Bumps the version to 1.8.0 for the next release.

Highlights since v1.7.0:

- fix: invisible operators U+2061-U+2064 no longer leak into the output (#73)
- fix: bare `<mtable>` and orphan `<mtr>` now wrap in `matrix`/`aligned` environments — obsidian-clipper case (#75)
- fix: `<mmultiscripts>` rewritten — prescripts attach as `{}_{a}^{b}`, all script pairs kept, base-only accepted (#78)
- fix: unicode double-bar norms `∥`/`‖` as proper `\|` delimiters, including scripted norms (#79)
- fix: corrected `≧`, `∼` and `↦` operator mappings (#75)
- feat: internal visual playground under `eval/` (not shipped) (#76)

Pre-bump smoke test: tarball ships `dist/` only; README examples pass in ESM and CJS; types resolve; all 18 release checks asserted against the installed tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)