### PR TITLE
fix(tokens): keep mtext unicode runs intact and escape LaTeX specials

### DIFF
--- a/src/data/usecases/mathml-to-latex-convertion/converters/mi/character.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mi/character.ts
@@ -1,5 +1,5 @@
 import { ownLookup } from '../../../../helpers';
-import { allMathSymbolsByChar, allMathSymbolsByGlyph, mathNumberByGlyph } from '../../../../../syntax';
+import { LatexSpecials, allMathSymbolsByChar, allMathSymbolsByGlyph, mathNumberByGlyph } from '../../../../../syntax';
 import { HashUTF8ToLtXConverter } from '../../../../../syntax/utf8-converter';
 
 /** Resolves a single identifier value to its LaTeX command via symbol lookup tables, falling back to UTF-8 conversion. */
@@ -14,15 +14,25 @@ export class Character {
     return new Character(value)._apply();
   }
 
-  private _apply(): string {
+  /** The lookup-table mapping for the value, or undefined when only the fallbacks would apply. */
+  static findMapping(value: string): string | undefined {
+    const character = new Character(value);
+
     // `??` instead of `||`: entries mapped to an empty string (e.g. the
     // invisible operators U+2061-U+2064) are valid results, not lookup misses.
-    return (
-      this._findByCharacter() ??
-      this._findByGlyph() ??
-      this._findByNumber() ??
-      new HashUTF8ToLtXConverter().convert(this._value)
-    );
+    return character._findByCharacter() ?? character._findByGlyph() ?? character._findByNumber();
+  }
+
+  private _apply(): string {
+    const mapped = Character.findMapping(this._value);
+    if (mapped !== undefined) return mapped;
+
+    const converted = new HashUTF8ToLtXConverter().convert(this._value);
+    if (converted !== this._value) return converted;
+
+    // No mapping anywhere: the value reaches the output verbatim, so LaTeX
+    // specials must be escaped to stay literal glyphs.
+    return LatexSpecials.escapeForMath(this._value);
   }
 
   private _findByCharacter(): string | undefined {

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mi/mi.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mi/mi.test.ts
@@ -20,4 +20,9 @@ describe('MI', () => {
   it('ignores an unknown mathvariant', () => {
     expect(new MI(mi('x', { mathvariant: 'nonsense' })).convert()).toBe('x');
   });
+
+  it('escapes LaTeX specials in unmapped values so they stay literal', () => {
+    expect(new MI(mi('x_i')).convert()).toBe('x\\_i');
+    expect(new MI(mi('a#b')).convert()).toBe('a\\#b');
+  });
 });

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mn.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mn.test.ts
@@ -11,4 +11,9 @@ describe('MN', () => {
   it('trims surrounding whitespace', () => {
     expect(new MN(mn('  7  ')).convert()).toBe('7');
   });
+
+  it('escapes LaTeX specials in unmapped values', () => {
+    expect(new MN(mn('#1')).convert()).toBe('\\#1');
+    expect(new MN(mn('$5.00')).convert()).toBe('\\$5.00');
+  });
 });

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mn.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mn.ts
@@ -1,13 +1,14 @@
 import { ToLaTeXConverter } from '../../../../domain/usecases/to-latex-converter';
 import { MathMLElement } from '../../../protocols/mathml-element';
 import { normalizeWhiteSpaces, ownLookup } from '../../../helpers';
-import { mathNumberByGlyph } from '../../../../syntax';
+import { LatexSpecials, mathNumberByGlyph } from '../../../../syntax';
 
 /**
  * Converts a MathML `<mn>` (number) element into LaTeX.
  *
  * Normalizes/trims the value and maps it through the number-by-glyph table,
- * returning the raw normalized value when no mapping exists.
+ * returning the normalized value with LaTeX specials escaped when no mapping
+ * exists (`#1` would otherwise not even compile).
  *
  * @example
  * // <mn>42</mn> -> 42
@@ -25,7 +26,8 @@ export class MN implements ToLaTeXConverter {
   convert(): string {
     const normalizedValue = normalizeWhiteSpaces(this._mathmlElement.value).trim();
     const convertedValue = ownLookup(mathNumberByGlyph, normalizedValue);
+    if (convertedValue !== undefined) return convertedValue;
 
-    return convertedValue || normalizedValue;
+    return LatexSpecials.escapeForMath(normalizedValue);
   }
 }

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mo/mo.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mo/mo.test.ts
@@ -8,6 +8,8 @@ describe('MO', () => {
     ['returns a simple operator as-is', '+', '+'],
     ['maps a known operator glyph to its command', '∑', '\\sum'],
     ['trims surrounding whitespace', '  =  ', '='],
+    ['maps a lone underscore to a literal escape', '_', '\\_'],
+    ['escapes LaTeX specials in unmapped values', 'a$b', 'a\\$b'],
   ])('%s', (_name, value, expected) => {
     expect(new MO(mo(value)).convert()).toBe(expected);
   });

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mo/operator.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mo/operator.ts
@@ -1,6 +1,7 @@
 import { ownLookup } from '../../../../helpers';
 import {
   HashUTF8ToLtXConverter,
+  LatexSpecials,
   allMathOperatorsByChar,
   allMathOperatorsByGlyph,
   mathNumberByGlyph,
@@ -21,12 +22,15 @@ export class Operator {
   private _operate(): string {
     // `??` instead of `||`: entries mapped to an empty string (e.g. the
     // invisible operators U+2061-U+2064) are valid results, not lookup misses.
-    return (
-      this._findByCharacter() ??
-      this._findByGlyph() ??
-      this._findByNumber() ??
-      new HashUTF8ToLtXConverter().convert(this._value)
-    );
+    const mapped = this._findByCharacter() ?? this._findByGlyph() ?? this._findByNumber();
+    if (mapped !== undefined) return mapped;
+
+    const converted = new HashUTF8ToLtXConverter().convert(this._value);
+    if (converted !== this._value) return converted;
+
+    // No mapping anywhere: the value reaches the output verbatim, so LaTeX
+    // specials must be escaped to stay literal glyphs.
+    return LatexSpecials.escapeForMath(this._value);
   }
 
   private _findByCharacter(): string | undefined {

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mtext/mtext.integration.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mtext/mtext.integration.test.ts
@@ -123,6 +123,36 @@ describe('mtext (integration)', () => {
 `,
       latex: '\\text{Creepy}',
     },
+    {
+      name: 'keep accented text as a single literal run',
+      mathml: '<math><mtext>café</mtext></math>',
+      latex: '\\text{café}',
+    },
+    {
+      name: 'keep accented words and spaces together',
+      mathml: '<math><mtext>São Paulo</mtext></math>',
+      latex: '\\text{São Paulo}',
+    },
+    {
+      name: 'escape an underscore so it does not become a subscript',
+      mathml: '<math><mtext>a_b</mtext></math>',
+      latex: '\\text{a\\_b}',
+    },
+    {
+      name: 'escape braces so they do not group silently',
+      mathml: '<math><mtext>{x}</mtext></math>',
+      latex: '\\text{\\{x\\}}',
+    },
+    {
+      name: 'escape percent and dollar inside the run',
+      mathml: '<math><mtext>preço: R$ 5</mtext></math>',
+      latex: '\\text{preço: R\\$ 5}',
+    },
+    {
+      name: 'still delegate known math glyphs to math mode',
+      mathml: '<math><mtext>T = 2α</mtext></math>',
+      latex: '\\text{T = 2}\\alpha',
+    },
   ])('$name', ({ mathml, latex }) => {
     expect(MathMLToLaTeX.convert(mathml)).toBe(latex);
   });

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mtext/mtext.test.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mtext/mtext.test.ts
@@ -17,7 +17,22 @@ describe('MText', () => {
     expect(new MText(mtext('hi', { mathvariant: 'bold' })).convert()).toBe('\\textbf{hi}');
   });
 
-  it('delegates standalone symbols to the mi converter', () => {
-    expect(new MText(mtext('a+b')).convert()).toBe('\\text{a}+\\text{b}');
+  it('keeps plain punctuation inside the text run', () => {
+    expect(new MText(mtext('a+b')).convert()).toBe('\\text{a+b}');
+  });
+
+  it('keeps accented letters literal inside the text run', () => {
+    expect(new MText(mtext('café')).convert()).toBe('\\text{café}');
+  });
+
+  it('escapes LaTeX specials so they stay literal glyphs', () => {
+    expect(new MText(mtext('a_b')).convert()).toBe('\\text{a\\_b}');
+    expect(new MText(mtext('{x}')).convert()).toBe('\\text{\\{x\\}}');
+    expect(new MText(mtext('50% off')).convert()).toBe('\\text{50\\% off}');
+    expect(new MText(mtext('x ~ y')).convert()).toBe('\\text{x \\textasciitilde{} y}');
+  });
+
+  it('delegates symbols the lookup tables know to the mi converter', () => {
+    expect(new MText(mtext('T = 2α')).convert()).toBe('\\text{T = 2}\\alpha');
   });
 });

--- a/src/data/usecases/mathml-to-latex-convertion/converters/mtext/mtext.ts
+++ b/src/data/usecases/mathml-to-latex-convertion/converters/mtext/mtext.ts
@@ -1,17 +1,24 @@
 import { ToLaTeXConverter } from '../../../../../domain/usecases/to-latex-converter';
 import { MathMLElement } from '../../../../protocols/mathml-element';
+import { LatexSpecials } from '../../../../../syntax';
 import { MI } from '../mi';
+import { Character } from '../mi/character';
 import { TextCommand } from './text-command';
 
 /**
  * Converts a MathML `<mtext>` element into LaTeX.
  *
- * Splits the text into runs of alphanumeric/space characters and standalone
- * symbols: alphanumeric runs are wrapped by the `mathvariant` text command while
- * each symbol is delegated to the `<mi>` converter.
+ * Keeps the content as a single text run wrapped by the `mathvariant` text
+ * command: ASCII alphanumerics and spaces verbatim, LaTeX specials escaped, and
+ * characters without a symbol-table mapping (accented letters, plain
+ * punctuation) kept literal, since `\text{...}` renders unicode directly. Only
+ * glyphs the symbol tables know (Greek letters, arrows, invisible operators)
+ * leave the run and are delegated to the `<mi>` converter as math.
  *
  * @example
  * // <mtext mathvariant="bold">hi</mtext> -> \textbf{hi}
+ * // <mtext>café</mtext> -> \text{café}
+ * // <mtext>a_b</mtext> -> \text{a\_b}
  */
 export class MText implements ToLaTeXConverter {
   private readonly _mathmlElement: MathMLElement;
@@ -25,51 +32,38 @@ export class MText implements ToLaTeXConverter {
    */
   convert(): string {
     const { attributes, value } = this._mathmlElement;
+    const textCommand = new TextCommand(attributes.mathvariant);
 
     return [...value]
-      .map<Char>((char) => {
-        // if is a letter, number or space, return it
-        if (/^[a-zA-Z0-9]$/.test(char) || char === ' ')
-          return {
-            value: char,
-            isAlphanumeric: true,
-          };
-
-        // if is a symbol, set it to mi parser
-        return {
-          value: char,
-          isAlphanumeric: false,
-        };
-      })
-      .reduce<Char[]>((acc, char) => {
-        // merge consecutive alphanumeric characters
-        if (char.isAlphanumeric) {
-          const lastChar = acc[acc.length - 1];
-          if (lastChar && lastChar.isAlphanumeric) {
-            lastChar.value += char.value;
-            return acc;
-          }
+      .map((char) => this._classify(char))
+      .reduce<Run[]>((runs, run) => {
+        // merge consecutive text characters into a single run
+        const lastRun = runs[runs.length - 1];
+        if (run.isText && lastRun && lastRun.isText) {
+          lastRun.value += run.value;
+          return runs;
         }
 
-        return [...acc, char];
+        return [...runs, run];
       }, [])
-      .map((char) => {
-        if (!char.isAlphanumeric) {
-          return new MI({
-            name: 'mi',
-            attributes: {},
-            children: [],
-            value: char.value,
-          }).convert();
-        }
-
-        return new TextCommand(attributes.mathvariant).apply(char.value);
-      })
+      .map((run) => (run.isText ? textCommand.apply(run.value) : this._convertSymbol(run.value)))
       .join('');
+  }
+
+  private _classify(char: string): Run {
+    if (/^[a-zA-Z0-9]$/.test(char) || char === ' ') return { value: char, isText: true };
+    if (LatexSpecials.isSpecial(char)) return { value: LatexSpecials.escapeForText(char), isText: true };
+    if (Character.findMapping(char) !== undefined) return { value: char, isText: false };
+
+    return { value: char, isText: true };
+  }
+
+  private _convertSymbol(value: string): string {
+    return new MI({ name: 'mi', attributes: {}, children: [], value }).convert();
   }
 }
 
-type Char = {
+type Run = {
   value: string;
-  isAlphanumeric: boolean;
+  isText: boolean;
 };

--- a/src/latex-specials-invariant.test.ts
+++ b/src/latex-specials-invariant.test.ts
@@ -1,0 +1,76 @@
+import { MathMLToLaTeX } from '.';
+
+/**
+ * Property: token content (`mtext`, `mi`, `mn`, `mo`) never leaks an active
+ * LaTeX special into the output. Whatever the input text, every `# $ % & _`
+ * in the converted LaTeX is escaped, `~ ^ \` only appear as commands, and
+ * grouping braces stay balanced — so raw token text can never act as LaTeX
+ * syntax (macro parameter, math shift, subscript, grouping).
+ */
+describe('latex specials invariant', () => {
+  const SAMPLES_PER_TOKEN = 500;
+
+  it.each(['mtext', 'mi', 'mn', 'mo'])('escapes every special leaking through <%s>', (tag) => {
+    const random = lcg(SEED_BY_TAG[tag]);
+
+    for (let sample = 0; sample < SAMPLES_PER_TOKEN; sample++) {
+      const text = randomText(random);
+      const mathml = `<math><${tag}>${xmlEscape(text)}</${tag}></math>`;
+
+      const latex = MathMLToLaTeX.convert(mathml);
+      const residue = stripCommands(latex);
+
+      expect({ tag, text, latex, leaked: findLeak(residue) }).toEqual({ tag, text, latex, leaked: null });
+    }
+  });
+});
+
+type Random = () => number;
+
+/** Deterministic linear congruential generator, so failures reproduce by seed. */
+const lcg = (seed: number): Random => {
+  let state = seed >>> 0;
+  return () => (state = (state * 1664525 + 1013904223) >>> 0) / 0x100000000;
+};
+
+const SEED_BY_TAG: Record<string, number> = { mtext: 1, mi: 2, mn: 3, mo: 4 };
+
+// Letters, accents, digits, every LaTeX special, plain punctuation and glyphs
+// the lookup tables know — the mix real documents throw at token elements.
+const TEXT_CHARS = [
+  ...'aBz39 ',
+  ...'éãçüñõ',
+  ...'αβΔ→±≤',
+  ...'#$%&_{}~^\\',
+  ...'+-=:;.,!?()<>/\'"',
+  '⁡',
+  '⁢',
+  '日',
+];
+
+const randomText = (random: Random): string => {
+  const length = 1 + Math.floor(random() * 8);
+  let text = '';
+  for (let i = 0; i < length; i++) text += TEXT_CHARS[Math.floor(random() * TEXT_CHARS.length)];
+  return text;
+};
+
+const xmlEscape = (text: string): string =>
+  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+
+/** Removes LaTeX commands and single-char escapes, leaving only literal output text. */
+const stripCommands = (latex: string): string => latex.replace(/\\[a-zA-Z]+/g, '').replace(/\\[^a-zA-Z]/g, '');
+
+/** @returns the first special that survived unescaped, or null when the output is clean. */
+const findLeak = (residue: string): string | null => {
+  const leakedSpecial = residue.match(/[#$%&_~^\\]/);
+  if (leakedSpecial) return leakedSpecial[0];
+
+  let depth = 0;
+  for (const char of residue) {
+    if (char === '{') depth++;
+    if (char === '}') depth--;
+    if (depth < 0) return 'unbalanced }';
+  }
+  return depth === 0 ? null : 'unbalanced {';
+};

--- a/src/latex-specials-invariant.test.ts
+++ b/src/latex-specials-invariant.test.ts
@@ -37,16 +37,7 @@ const SEED_BY_TAG: Record<string, number> = { mtext: 1, mi: 2, mn: 3, mo: 4 };
 
 // Letters, accents, digits, every LaTeX special, plain punctuation and glyphs
 // the lookup tables know — the mix real documents throw at token elements.
-const TEXT_CHARS = [
-  ...'aBz39 ',
-  ...'éãçüñõ',
-  ...'αβΔ→±≤',
-  ...'#$%&_{}~^\\',
-  ...'+-=:;.,!?()<>/\'"',
-  '⁡',
-  '⁢',
-  '日',
-];
+const TEXT_CHARS = [...'aBz39 ', ...'éãçüñõ', ...'αβΔ→±≤', ...'#$%&_{}~^\\', ...'+-=:;.,!?()<>/\'"', '⁡', '⁢', '日'];
 
 const randomText = (random: Random): string => {
   const length = 1 + Math.floor(random() * 8);
@@ -56,7 +47,12 @@ const randomText = (random: Random): string => {
 };
 
 const xmlEscape = (text: string): string =>
-  text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;');
+  text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
 
 /** Removes LaTeX commands and single-char escapes, leaving only literal output text. */
 const stripCommands = (latex: string): string => latex.replace(/\\[a-zA-Z]+/g, '').replace(/\\[^a-zA-Z]/g, '');

--- a/src/robustness.test.ts
+++ b/src/robustness.test.ts
@@ -76,18 +76,25 @@ describe('#convert security and robustness', () => {
     // such as "constructor" or "toString" resolves through the prototype chain
     // instead of missing. An unknown token must instead fall through to its
     // literal text, exactly like any other unrecognized token (e.g. "foo").
-    const prototypeKeys = ['constructor', 'hasOwnProperty', 'toString', 'valueOf', '__proto__'];
+    // Underscores come out escaped, since `_` is LaTeX subscript syntax.
+    const prototypeKeys = [
+      ['constructor', 'constructor'],
+      ['hasOwnProperty', 'hasOwnProperty'],
+      ['toString', 'toString'],
+      ['valueOf', 'valueOf'],
+      ['__proto__', '\\_\\_proto\\_\\_'],
+    ];
 
-    it.each(prototypeKeys)('converts <mo>%s</mo> to its literal text', (token) => {
+    it.each(prototypeKeys)('converts <mo>%s</mo> to its literal text', (token, literal) => {
       const result = MathMLToLaTeX.convert(`<math><mo>${token}</mo></math>`);
 
-      expect(result).toBe(token);
+      expect(result).toBe(literal);
       expect(result).not.toContain('[native code]');
     });
 
-    it.each(prototypeKeys)('converts <mi>%s</mi> to its literal text', (token) => {
+    it.each(prototypeKeys)('converts <mi>%s</mi> to its literal text', (token, literal) => {
       expect(() => MathMLToLaTeX.convert(`<math><mi>${token}</mi></math>`)).not.toThrow();
-      expect(MathMLToLaTeX.convert(`<math><mi>${token}</mi></math>`)).toBe(token);
+      expect(MathMLToLaTeX.convert(`<math><mi>${token}</mi></math>`)).toBe(literal);
     });
   });
 

--- a/src/syntax/all-math-operators-by-char.ts
+++ b/src/syntax/all-math-operators-by-char.ts
@@ -4,7 +4,7 @@
  * `<mo>` converter to translate operator content into LaTeX.
  */
 export const allMathOperatorsByChar: Record<string, string> = {
-  _: '\\underline',
+  _: '\\_',
   '&#x23E1;': '\\underbrace',
   '&#x23E0;': '\\overbrace',
   '&#x23DF;': '\\underbrace',

--- a/src/syntax/all-math-operators-by-glyph.ts
+++ b/src/syntax/all-math-operators-by-glyph.ts
@@ -4,7 +4,7 @@
  * to translate operator content into LaTeX.
  */
 export const allMathOperatorsByGlyph: Record<string, string> = {
-  _: '\\underline',
+  _: '\\_',
   '⏡': '\\underbrace',
   '⏠': '\\overbrace',
   '⏟': '\\underbrace',

--- a/src/syntax/index.ts
+++ b/src/syntax/index.ts
@@ -4,5 +4,6 @@ export * from './all-math-symbols-by-char';
 export * from './all-math-symbols-by-glyph';
 export * from './fence-glyphs';
 export * from './latex-accents';
+export * from './latex-specials';
 export * from './math-numbers-by-glyph';
 export * from './utf8-converter';

--- a/src/syntax/latex-specials.test.ts
+++ b/src/syntax/latex-specials.test.ts
@@ -1,0 +1,35 @@
+import { LatexSpecials } from './latex-specials';
+
+describe('LatexSpecials', () => {
+  it('escapes the shared specials identically in both modes', () => {
+    const input = '#$%&_{}';
+    const expected = '\\#\\$\\%\\&\\_\\{\\}';
+
+    expect(LatexSpecials.escapeForMath(input)).toBe(expected);
+    expect(LatexSpecials.escapeForText(input)).toBe(expected);
+  });
+
+  it('escapes tilde, circumflex and backslash with math-mode commands', () => {
+    expect(LatexSpecials.escapeForMath('a~b')).toBe('a\\sim{}b');
+    expect(LatexSpecials.escapeForMath('a^b')).toBe('a\\hat{}b');
+    expect(LatexSpecials.escapeForMath('a\\b')).toBe('a\\backslash{}b');
+  });
+
+  it('escapes tilde, circumflex and backslash with text-mode commands', () => {
+    expect(LatexSpecials.escapeForText('a~b')).toBe('a\\textasciitilde{}b');
+    expect(LatexSpecials.escapeForText('a^b')).toBe('a\\textasciicircum{}b');
+    expect(LatexSpecials.escapeForText('a\\b')).toBe('a\\textbackslash{}b');
+  });
+
+  it('leaves non-special characters untouched', () => {
+    expect(LatexSpecials.escapeForMath('café α → 42')).toBe('café α → 42');
+    expect(LatexSpecials.escapeForText('café α → 42')).toBe('café α → 42');
+  });
+
+  it('tells specials apart from ordinary characters', () => {
+    expect(LatexSpecials.isSpecial('_')).toBe(true);
+    expect(LatexSpecials.isSpecial('\\')).toBe(true);
+    expect(LatexSpecials.isSpecial('a')).toBe(false);
+    expect(LatexSpecials.isSpecial('é')).toBe(false);
+  });
+});

--- a/src/syntax/latex-specials.ts
+++ b/src/syntax/latex-specials.ts
@@ -1,0 +1,62 @@
+/**
+ * Escapes the LaTeX special characters (`# $ % & _ { } ~ ^ \`) in plain text
+ * that reaches the output without a lookup-table mapping, so they render as
+ * literal glyphs instead of acting as LaTeX syntax (macro parameter, math
+ * shift, alignment, subscript/superscript, grouping). Tilde, circumflex and
+ * backslash have no universal escape: math mode and `\text{...}` accept
+ * different commands, hence the two maps.
+ */
+export class LatexSpecials {
+  private readonly _value: string;
+
+  constructor(value: string) {
+    this._value = value;
+  }
+
+  /** Escapes the value for math mode (`\sim`, `\hat{}`, `\backslash`). */
+  static escapeForMath(value: string): string {
+    return new LatexSpecials(value)._escape(mathModeEscapes);
+  }
+
+  /** Escapes the value for text mode, i.e. inside `\text{...}` and its variants. */
+  static escapeForText(value: string): string {
+    return new LatexSpecials(value)._escape(textModeEscapes);
+  }
+
+  /** Whether the single character is LaTeX syntax that needs escaping. */
+  static isSpecial(char: string): boolean {
+    return Object.prototype.hasOwnProperty.call(textModeEscapes, char);
+  }
+
+  private _escape(escapes: Record<string, string>): string {
+    return [...this._value]
+      .map((char) => (Object.prototype.hasOwnProperty.call(escapes, char) ? escapes[char] : char))
+      .join('');
+  }
+}
+
+const sharedEscapes: Record<string, string> = {
+  '#': '\\#',
+  $: '\\$',
+  '%': '\\%',
+  '&': '\\&',
+  _: '\\_',
+  '{': '\\{',
+  '}': '\\}',
+};
+
+// The `{}` terminator keeps the command from swallowing a following letter
+// (`a~b` must not become the undefined `\simb`).
+const mathModeEscapes: Record<string, string> = {
+  ...sharedEscapes,
+  '~': '\\sim{}',
+  '^': '\\hat{}',
+  '\\': '\\backslash{}',
+};
+
+const textModeEscapes: Record<string, string> = {
+  ...sharedEscapes,
+  '~': '\\textasciitilde{}',
+  '^': '\\textasciicircum{}',
+  '\\': '\\textbackslash{}',
+};


### PR DESCRIPTION
## Summary

Unmapped token text leaked raw into the output: `<mtext>café</mtext>` was shredded into `\text{caf}\acute{e}` (math-mode accents inside text, `ç` even mapped to the wrong glyph `\dot{c}`), and LaTeX specials passed through as live syntax — `<mtext>a_b</mtext>` produced a real subscript, `<mn>#1</mn>` and `<mn>$5.00</mn>` did not even compile.

## Changes

- New `LatexSpecials` (`src/syntax/latex-specials.ts`) escaping `# $ % & _ { } ~ ^ \` with mode-aware commands (`\sim{}`/`\hat{}`/`\backslash{}` in math, `\textasciitilde{}`/`\textasciicircum{}`/`\textbackslash{}` in text), applied at the unmapped-value fallback of `mi`, `mo` and `mn`.
- `MText` rewritten: content stays as a single text run (`\text{café}`, `\text{São Paulo}`, `\text{a\_b}`); only glyphs the symbol tables know (Greek letters, arrows, invisible operators) still convert as math. Unmapped characters are no longer routed through the `mi` accent fallback.
- Fixed the `_` operator mapping (`\underline` with no argument, which compiles neither standalone nor as `\underset{\underline}{x}`) to the literal `\_`.
- Property-based test (`latex-specials-invariant.test.ts`, 4x500 seeded samples) guarantees no special ever survives unescaped and braces stay balanced; validated against KaTeX (2000-case sweep, sole failure is the pre-existing standalone `<mo>^</mo>` → `\hat`, left for the accents work).

Note: outputs changed for text content that previously leaked syntax, e.g. `\text{a}+\text{b}` → `\text{a+b}` and `\text{50}\%\text{ off}` → `\text{50\% off}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)